### PR TITLE
When we update an underlying value, update raw too.

### DIFF
--- a/packages/mstform/src/accessor.ts
+++ b/packages/mstform/src/accessor.ts
@@ -50,6 +50,8 @@ export interface IFormAccessor<M, D extends FormDefinition<M>> {
 
   repeatingForm<K extends keyof M>(name: K): RepeatingFormAccess<M, D, K>;
 
+  access(name: string): Accessor;
+
   accessors: Accessor[];
 
   flatAccessors: Accessor[];
@@ -97,6 +99,24 @@ export class FormAccessor<M, D extends FormDefinition<M>>
       }
     });
     return result;
+  }
+
+  access(name: string): Accessor {
+    try {
+      return this.field(name as keyof M);
+    } catch {
+      // XXX catching any error isn't the prettiest way to do this..
+      return this.repeatingForm(name as keyof M);
+    }
+  }
+
+  accessBySteps(steps: string[]): Accessor {
+    const [first, ...rest] = steps;
+    const accessor = this.access(first);
+    if (rest.length === 0) {
+      return accessor;
+    }
+    return accessor.accessBySteps(rest);
   }
 
   field<K extends keyof M>(name: K): FieldAccess<M, D, K> {
@@ -336,6 +356,10 @@ export class FieldAccessor<M, R, V> {
       help: error
     };
   }
+
+  accessBySteps(steps: string[]): Accessor {
+    throw new Error("Cannot step through field accessor");
+  }
 }
 
 export class RepeatingFormAccessor<M, D extends FormDefinition<M>> {
@@ -393,6 +417,16 @@ export class RepeatingFormAccessor<M, D extends FormDefinition<M>> {
       result.push(...accessor.flatAccessors);
     });
     return result;
+  }
+
+  accessBySteps(steps: string[]): Accessor {
+    const [first, ...rest] = steps;
+    const number = parseInt(first, 10);
+    if (isNaN(number)) {
+      throw new Error("Expected index of repeating form");
+    }
+    const accessor = this.index(number);
+    return accessor.accessBySteps(rest);
   }
 
   @computed
@@ -455,6 +489,19 @@ export class RepeatingFormIndexedAccessor<M, D extends FormDefinition<M>>
 
   async validate(): Promise<boolean> {
     return this.formAccessor.validate();
+  }
+
+  access(name: string): Accessor {
+    return this.formAccessor.access(name);
+  }
+
+  accessBySteps(steps: string[]): Accessor {
+    const [first, ...rest] = steps;
+    const accessor = this.access(first);
+    if (rest.length === 0) {
+      return accessor;
+    }
+    return accessor.accessBySteps(steps);
   }
 
   field<K extends keyof M>(name: K): FieldAccess<M, D, K> {

--- a/packages/mstform/src/index.ts
+++ b/packages/mstform/src/index.ts
@@ -2,3 +2,4 @@ export * from "./form";
 export * from "./types";
 export * from "./converter";
 export * from "./converters";
+export * from "./accessor";

--- a/packages/mstform/test/accessor.ts
+++ b/packages/mstform/test/accessor.ts
@@ -1,0 +1,59 @@
+import { configure, IReactionDisposer } from "mobx";
+import { getSnapshot, types } from "mobx-state-tree";
+import {
+  Converter,
+  Field,
+  Form,
+  RepeatingForm,
+  converters,
+  FieldAccessor
+} from "../src";
+
+// "strict" leads to trouble during initialization. we may want to lift this
+// restriction in ispnext in the future as we use MST now, which has its
+// own mechanism
+configure({ enforceActions: true });
+
+test("accessByPath simple field", async () => {
+  const M = types.model("M", {
+    foo: types.number
+  });
+  const form = new Form(M, {
+    foo: new Field(converters.number)
+  });
+
+  const o = M.create({ foo: 3 });
+
+  const state = form.state(o);
+  const accessor = state.accessByPath("/foo");
+  expect(accessor).toBeInstanceOf(FieldAccessor);
+  if (!(accessor instanceof FieldAccessor)) {
+    throw new Error("For the typechecker");
+  }
+  expect(accessor.value).toEqual(3);
+});
+
+test("accessByPath repeating form", async () => {
+  const N = types.model("N", {
+    foo: types.number
+  });
+  const M = types.model("M", {
+    entries: types.array(N)
+  });
+
+  const form = new Form(M, {
+    entries: new RepeatingForm({
+      foo: new Field(converters.number)
+    })
+  });
+
+  const o = M.create({ entries: [{ foo: 3 }] });
+
+  const state = form.state(o);
+  const accessor = state.accessByPath("/entries/0/foo");
+  expect(accessor).toBeInstanceOf(FieldAccessor);
+  if (!(accessor instanceof FieldAccessor)) {
+    throw new Error("For the typechecker");
+  }
+  expect(accessor.value).toEqual(3);
+});

--- a/packages/mstform/test/form.ts
+++ b/packages/mstform/test/form.ts
@@ -24,11 +24,11 @@ test("a simple form", async () => {
   const field = state.field("foo");
 
   expect(field.raw).toEqual("FOO");
-  await field.handleChange("BAR");
+  await field.setRaw("BAR");
   expect(field.raw).toEqual("BAR");
   expect(field.error).toEqual("Wrong");
   expect(field.value).toEqual("FOO");
-  await field.handleChange("correct");
+  await field.setRaw("correct");
   expect(field.error).toBeUndefined();
   expect(field.value).toEqual("correct");
 
@@ -1116,11 +1116,10 @@ test("setting value on model will update form", async () => {
   o.update("BAR");
   expect(field.raw).toEqual("BAR");
 
-  // as soon as someone starts typing however, the raw is not updated
+  // the raw is also immediately updated
   field.setRaw("QUX");
   o.update("BACK");
-  expect(field.raw).toEqual("QUX");
-  // TODO: provide a way to clear raw so that updating works?
+  expect(field.raw).toEqual("BACK");
 });
 
 test("no validation before save", async () => {


### PR DESCRIPTION
This turned out to be a problem for the change hook otherwise.