### PR TITLE
an onFocus hook for mstform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,3 +511,25 @@ by the field `b`. We implement a change hook to call that action whenever
 `a` is changed. This only happens if `a` passes validation -- changes
 to `a` that result in an error message don't result in an execution
 of the `change` hook.
+
+## Focus hook
+
+You may want to react to field focus events. You can do this with a custom
+onFocus event handler on the input element, but in some cases you want to react
+generically to _all_ focus events in a form. You can pass a special hook
+to the form state options for this:
+
+```javascript
+const state = form.state(o, {
+  focus: (ev, accessor) => {
+    // do something here
+  }
+});
+```
+
+The hook receives the event and the focused field accessor. You can use the
+accessor to get the field name (`accessor.name`), value (`accessor.value`),
+etc. When you define the hook, `inputProps` on the field accessor contains an
+`onFocus` handler, so if you use that with the field it is there automatically.
+For fields where you cannot use `inputProps` directly you need to bind
+``inputProps.onFocus` manually.

--- a/packages/mstform/src/accessor.ts
+++ b/packages/mstform/src/accessor.ts
@@ -348,13 +348,24 @@ export class FieldAccessor<M, R, V> {
     await this.setRaw(raw);
   };
 
+  handleFocus = (event: any) => {
+    if (this.state.focusFunc == null) {
+      return;
+    }
+    this.state.focusFunc(event, this);
+  };
+
   @computed
   get inputProps() {
-    return {
+    const result: any = {
       disabled: this.disabled,
       value: this.raw,
       onChange: this.handleChange
     };
+    if (this.state.focusFunc != null) {
+      result.onFocus = this.handleFocus;
+    }
+    return result;
   }
 
   @computed

--- a/packages/mstform/src/types.ts
+++ b/packages/mstform/src/types.ts
@@ -29,12 +29,3 @@ export interface FieldOptions<R, V> {
   derived?: Derived<V>;
   change?: Change<V>;
 }
-
-export interface SaveFunc<M> {
-  (node: M): any;
-}
-
-// TODO: implement blur and pause validation
-// blur would validate immediately after blur
-// pause would show validation after the user stops input for a while
-export type ValidationOption = "immediate" | "no"; //  | "blur" | "pause";

--- a/packages/mstform/test/form.ts
+++ b/packages/mstform/test/form.ts
@@ -1965,3 +1965,47 @@ test("raw update and multiple accessors", async () => {
     }
   ]);
 });
+
+test("focus hook", async () => {
+  const M = types.model("M", {
+    foo: types.string,
+    bar: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string),
+    bar: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO", bar: "BAR" });
+
+  const focused: any[] = [];
+
+  const state = form.state(o, {
+    focus: (ev, accessor) => {
+      focused.push({
+        raw: accessor.raw,
+        value: accessor.value,
+        name: accessor.name
+      });
+    }
+  });
+
+  const fooField = state.field("foo");
+  expect(fooField.inputProps.onFocus).toBeDefined();
+
+  fooField.handleFocus(null);
+
+  const barField = state.field("bar");
+  barField.handleFocus(null);
+
+  expect(focused).toEqual([
+    { name: "foo", raw: "FOO", value: "FOO" },
+    { name: "bar", raw: "BAR", value: "BAR" }
+  ]);
+
+  // no focus hook
+  const state2 = form.state(o);
+  const fooField2 = state2.field("foo");
+  expect(fooField2.inputProps.onFocus).toBeUndefined();
+});


### PR DESCRIPTION
We have a state-level onFocus hook. It's automatically included in inputProps when defined. You can access the accessor (field) in the onFocus hook so you can get information like `name` out. I moved a few definitions from `types.ts` into `state.ts` as they make more sense there.