### PR TITLE
support for isReadOnly to help drive read-only React components.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 0.14
+
+-   Support for isReadOnly hook and field accessor `readOnly`. This is sent along
+    with `inputProps` only if isReadOnly returns `true` for that accessor.
+
 # 0.13
 
 -   Update documentation to eliminate references to `this.state`,

--- a/README.md
+++ b/README.md
@@ -651,14 +651,14 @@ const tabAValid = groupA.isValid;
 const tabBValid = groupB.isValid;
 ```
 
-## Disabled and hidden fields
+## Disabled, hidden and readOnly fields
 
-mstform has two hooks that let you calculate `hidden` and `disabled`
-state based on the field accessor. Here is a small example that makes the
-`foo` field disabled. This uses the JSON Path functionality of mstform
-to determine whether a field is disabled, but any operation can be
-implemented here. You could for instance retrieve information about which
-fields are disabled dynamically from the backend before you display the form.
+mstform has hooks that let you calculate `hidden`, `disabled` and `readOnly`
+state based on the field accessor. Here is a small example that makes the `foo`
+field disabled. This uses the JSON Path functionality of mstform to determine
+whether a field is disabled, but any operation can be implemented here. You
+could for instance retrieve information about which fields are disabled
+dynamically from the backend before you display the form.
 
 ```js
 const state = form.state(o, {
@@ -671,9 +671,14 @@ determine whether a repeating form is disabled from add and remove using
 `isRepeatingFormDisabled`. It's up to you to use this information to render the
 add and remove buttons with the disabled status, however.
 
-`isDisabled` makes the `disabled` prop `true` in `accessor.inputProps`. There
-is no such behavior for `hidden`; use `accessor.hidden` in your form rendering
-code to determine whether a field wants to be hidden.
+To implement readOnly behavior, pass in an `isReadOnly` function.
+
+`isDisabled` returning `true` makes the `disabled` prop `true` in
+`accessor.inputProps`. If `isReadOnly` is true, the `readOnly` flag is added to
+`accessor.inputProps`; otherwise it's absent, but it's up to you to ensure your
+React input widgets support a `readOnly` prop (HTML input does). There is no
+such behavior for `hidden`; use `accessor.hidden` in your form rendering code
+to determine whether a field wants to be hidden.
 
 ## Extra validation
 

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -376,6 +376,11 @@ export class FieldAccessor<M, R, V> {
     return this.state.isHiddenFunc(this);
   }
 
+  @computed
+  get readOnly(): boolean {
+    return this.state.isReadOnlyFunc(this);
+  }
+
   async validate(): Promise<boolean> {
     await this.setRaw(this.raw);
     return this.isValid;
@@ -458,6 +463,9 @@ export class FieldAccessor<M, R, V> {
   get inputProps() {
     const result: any = this.field.controlled(this);
     result.disabled = this.disabled;
+    if (this.readOnly) {
+      result.readOnly = this.readOnly;
+    }
     if (this.state.focusFunc != null) {
       result.onFocus = this.handleFocus;
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -12,7 +12,7 @@ import {
   RepeatingFormAccessorAllows,
   SubFormAccess
 } from "./accessor";
-import { Form, FormDefinition } from "./form";
+import { Form, FormDefinition, Field } from "./form";
 import {
   addPath,
   deepCopy,
@@ -46,6 +46,7 @@ export interface FormStateOptions<M> {
   };
   isDisabled?: FieldAccessorAllows;
   isHidden?: FieldAccessorAllows;
+  isReadOnly?: FieldAccessorAllows;
   isRepeatingFormDisabled?: RepeatingFormAccessorAllows;
   extraValidation?: ExtraValidation;
   focus?: FocusFunc<M, any, any>;
@@ -83,6 +84,7 @@ export class FormState<M, D extends FormDefinition<M>>
   validationPauseDuration: number;
   isDisabledFunc: FieldAccessorAllows;
   isHiddenFunc: FieldAccessorAllows;
+  isReadOnlyFunc: FieldAccessorAllows;
   isRepeatingFormDisabledFunc: RepeatingFormAccessorAllows;
   extraValidationFunc: ExtraValidation;
   private noRawUpdate: boolean;
@@ -115,6 +117,7 @@ export class FormState<M, D extends FormDefinition<M>>
       this.saveFunc = defaultSaveFunc;
       this.isDisabledFunc = () => false;
       this.isHiddenFunc = () => false;
+      this.isReadOnlyFunc = () => false;
       this.isRepeatingFormDisabledFunc = () => false;
       this.extraValidationFunc = () => false;
       this.validationBeforeSave = "immediate";
@@ -128,6 +131,9 @@ export class FormState<M, D extends FormDefinition<M>>
         ? options.isDisabled
         : () => false;
       this.isHiddenFunc = options.isHidden ? options.isHidden : () => false;
+      this.isReadOnlyFunc = options.isReadOnly
+        ? options.isReadOnly
+        : () => false;
       this.isRepeatingFormDisabledFunc = options.isRepeatingFormDisabled
         ? options.isRepeatingFormDisabled
         : () => false;

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1605,6 +1605,55 @@ test("a form with a repeating disabled field", async () => {
   expect(repeating.index(0).field("bar").disabled).toBeFalsy();
 });
 
+test("a form with a hidden field", async () => {
+  const M = types.model("M", {
+    foo: types.string,
+    bar: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string),
+    bar: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO", bar: "BAR" });
+
+  const state = form.state(o, {
+    isHidden: accessor => accessor.path.startsWith("/foo")
+  });
+  const fooField = state.field("foo");
+  const barField = state.field("bar");
+
+  expect(fooField.hidden).toBeTruthy();
+  expect(barField.hidden).toBeFalsy();
+});
+
+test("a form with a readOnly field", async () => {
+  const M = types.model("M", {
+    foo: types.string,
+    bar: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string),
+    bar: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO", bar: "BAR" });
+
+  const state = form.state(o, {
+    isReadOnly: accessor => accessor.path.startsWith("/foo")
+  });
+  const fooField = state.field("foo");
+  const barField = state.field("bar");
+
+  expect(fooField.readOnly).toBeTruthy();
+  expect(fooField.inputProps.readOnly).toBeTruthy();
+
+  expect(barField.readOnly).toBeFalsy();
+  expect(barField.inputProps.readOnly).toBeUndefined();
+});
+
 test("extra validation", async () => {
   const M = types.model("M", {
     foo: types.string,


### PR DESCRIPTION
We add a isReadOnly hook. We also expand the tests for hidden a bit. The isReadOnly hook by itself doesn't do anything - we need to implement widgets that can process the `readOnly` prop, but it's the support we need inside mstform.