### PR TITLE
Boolean never required

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 0.17.0
+
+-   Added a neverRequired option to converters. Make it so that the
+    boolean converter is never required.
+
 # 0.16.1
 
 -   Actual release with what I intended.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # 0.17.0
 
--   Added a neverRequired option to converters. Make it so that the
-    boolean converter is never required.
+-   Added a `neverRequired` option to converters. Make it so that the
+    `boolean` converter is never required.
 
 # 0.16.1
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -7,6 +7,7 @@ export interface ConverterOptions<R, V> {
   validate?(value: V): boolean | Promise<boolean>;
   emptyRaw: R;
   defaultControlled?: Controlled;
+  neverRequired?: boolean;
 }
 
 export interface IConverter<R, V> {
@@ -14,6 +15,7 @@ export interface IConverter<R, V> {
   convert(raw: R): Promise<ConversionResponse<V>>;
   render(value: V): R;
   defaultControlled: Controlled;
+  neverRequired: boolean;
 }
 
 export class ConversionValue<V> {
@@ -29,12 +31,14 @@ export type ConversionResponse<V> = ConversionError | ConversionValue<V>;
 export class Converter<R, V> implements IConverter<R, V> {
   emptyRaw: R;
   defaultControlled: Controlled;
+  neverRequired: boolean = false;
 
   constructor(public definition: ConverterOptions<R, V>) {
     this.emptyRaw = definition.emptyRaw;
     this.defaultControlled = definition.defaultControlled
       ? definition.defaultControlled
       : controlled.object;
+    this.neverRequired = !!definition.neverRequired;
   }
 
   async convert(raw: R): Promise<ConversionResponse<V>> {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -65,7 +65,8 @@ const boolean = new Converter<boolean, boolean>({
   render(value) {
     return value;
   },
-  defaultControlled: controlled.checked
+  defaultControlled: controlled.checked,
+  neverRequired: true
 });
 
 class Decimal implements IConverter<string, string> {
@@ -73,6 +74,7 @@ class Decimal implements IConverter<string, string> {
 
   emptyRaw: string;
   defaultControlled = controlled.value;
+  neverRequired = false;
 
   constructor(public maxWholeDigits: number, public decimalPlaces: number) {
     this.emptyRaw = "";
@@ -143,6 +145,7 @@ function maybe<R, V>(
 class StringMaybe<V> implements IConverter<string, V | null> {
   emptyRaw: string;
   defaultControlled = controlled.value;
+  neverRequired = false;
 
   constructor(public converter: StringConverter<V>) {
     this.emptyRaw = "";
@@ -166,6 +169,7 @@ class StringMaybe<V> implements IConverter<string, V | null> {
 class Model<M> implements IConverter<M | null, M> {
   emptyRaw: M | null;
   defaultControlled: Controlled;
+  neverRequired = false;
 
   constructor(model: IModelType<any, M>) {
     this.emptyRaw = null;

--- a/src/form.ts
+++ b/src/form.ts
@@ -150,7 +150,11 @@ export class Field<R, V> {
   }
 
   async process(raw: R, required: boolean): Promise<ProcessResponse<V>> {
-    if (raw === this.converter.emptyRaw && required) {
+    if (
+      !this.converter.neverRequired &&
+      raw === this.converter.emptyRaw &&
+      required
+    ) {
       return new ValidationMessage(this.requiredError);
     }
 

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1053,6 +1053,30 @@ test("required with string", async () => {
   expect(field.error).toEqual("Required");
 });
 
+test("required with boolean has no effect", async () => {
+  const M = types.model("M", {
+    foo: types.boolean
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.boolean, {
+      required: true
+    })
+  });
+
+  const o = M.create({ foo: false });
+
+  const state = form.state(o, { save: () => null });
+
+  const field = state.field("foo");
+
+  await field.setRaw(false);
+  expect(field.error).toBeUndefined();
+
+  await state.save();
+  expect(field.error).toBeUndefined();
+});
+
 test("required with maybe", async () => {
   const M = types.model("M", {
     foo: types.maybe(types.number)


### PR DESCRIPTION
Boolean fields should never be required: if they are not filled in, that's a legitimate value.