### PR TITLE
Add mode bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# 0.18.0
+
+-   Previously we tried to set a new repeating form in add mode if there
+    was a JSON patch from MST that added an item. Unfortunately this triggers
+    too often -- with applySnapshot for instance.
+
+    Instead we only set a new entry into add mode when we use the API on the
+    repeating form accessor: `push()` and `insert()`. This is only called by
+    form code itself so therefore safe to do.
+
 # 0.17.1
 
 -   When a field is `neverRequired` then we want the 'required' property

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -134,12 +134,15 @@ export class RepeatingFormAccessor<M, D extends FormDefinition<M>> {
   insert(index: number, node: any) {
     const path = this.path + "/" + index;
     applyPatch(this.state.node, [{ op: "add", path, value: node }]);
+    this.index(index).setAddMode();
   }
 
   push(node: any) {
     const a = resolvePath(this.state.node, this.path) as any[];
-    const path = this.path + "/" + a.length;
+    const index = a.length;
+    const path = this.path + "/" + index;
     applyPatch(this.state.node, [{ op: "add", path, value: node }]);
+    this.index(index).setAddMode();
   }
 
   remove(node: any) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -233,15 +233,9 @@ export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
 
     accessor.addIndex(index);
 
-    // after all this we can access it and set it into addMode
-    const indexedAccessor = this.accessByPath(path);
-    if (
-      indexedAccessor === undefined ||
-      !(indexedAccessor instanceof RepeatingFormIndexedAccessor)
-    ) {
-      return;
-    }
-    indexedAccessor.setAddMode();
+    // we cannot set it into add mode here, as this can be triggered
+    // by code like applySnapshot. Instead use the RepeatingFormAccessor
+    // API to ensure add mode is set
   }
 
   @action

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -242,6 +242,37 @@ test("repeating form insert", async () => {
   expect(field.value).toEqual("FLURB");
 });
 
+test("repeating form applySnapshot shouldn't trigger addMode", async () => {
+  const N = types.model("N", {
+    bar: types.string
+  });
+  const M = types.model("M", {
+    foo: types.array(N)
+  });
+
+  const form = new Form(M, {
+    foo: new RepeatingForm({
+      bar: new Field(converters.string)
+    })
+  });
+
+  const o = M.create({ foo: [{ bar: "BAR" }] });
+
+  const state = form.state(o);
+
+  const forms = state.repeatingForm("foo");
+  expect(forms.length).toBe(1);
+  const oneForm = forms.index(0);
+
+  const field = oneForm.field("bar");
+  expect(field.addMode).toBeFalsy();
+
+  applySnapshot(o, { foo: [{ bar: "BAZ" }] });
+  const oneForm2 = forms.index(0);
+  const field2 = oneForm2.field("bar");
+  expect(field2.addMode).toBeFalsy();
+});
+
 test("repeating form remove", async () => {
   const N = types.model("N", {
     bar: types.string


### PR DESCRIPTION
Previously we tried to set a new repeating form in add mode if there
was a JSON patch from MST that added an item. Unfortunately this triggers
too often -- with applySnapshot for instance. Instead we only set a new entry into add mode when we use the API on the repeating form accessor: `push()` and `insert()`. This is only called by form code itself so therefore safe to do.