### PR TITLE
add an update hook to mstform.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 0.24.0
+
+-   Implement a `update` hook on the state options that is called when a field is
+    changed and it passes validation.
+
 # 0.23.0
 
 -   Implement a `blur` hook that is called when the blur event fires for a

--- a/README.md
+++ b/README.md
@@ -890,7 +890,25 @@ etc. When you define the hook, `inputProps` on the field accessor contains an
 `onFocus`/`onBlur` handler, so if you use that with the field it is there
 automatically.
 
+## Update hook
+
+When you want to react to changes to any field value in the form, you can
+implement the update hook. This hook is triggered only when a change happens to
+the _value_, not when the _raw_ is updated, so only when the underlying
+instance that the form represents is updated. This means that if there are any
+client-side validation messages, the update hook isn't yet triggered.
+
+```js
+const state = form.state(o, {
+    update: accessor => {}
+});
+```
+
 ## Tips
 
 -   Don't name your form state `this.state` on a React component as this has a
     special meaning to React and can lead to odd bugs.
+
+```
+
+```

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -281,9 +281,16 @@ export class FieldAccessor<M, R, V> {
 
     this.state.setValueWithoutRawUpdate(this.path, processResult.value);
 
+    // XXX maybe rename this to 'update' as change might imply onChange
+    // this is why I named 'updateFunc' on state that way instead of
+    // 'changeFunc'
     const changeFunc = this.field.changeFunc;
     if (changeFunc != null) {
       changeFunc(this.node, processResult.value);
+    }
+    const updateFunc = this.state.updateFunc;
+    if (updateFunc != null) {
+      updateFunc(this);
     }
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -40,6 +40,10 @@ export interface EventFunc<M, R, V> {
   (event: any, accessor: FieldAccessor<M, R, V>): void;
 }
 
+export interface UpdateFunc<M, R, V> {
+  (accessor: FieldAccessor<M, R, V>): void;
+}
+
 // TODO: implement blur and pause validation
 // blur would validate immediately after blur
 // pause would show validation after the user stops input for a while
@@ -65,6 +69,7 @@ export interface FormStateOptions<M> {
   extraValidation?: ExtraValidation;
   focus?: EventFunc<M, any, any>;
   blur?: EventFunc<M, any, any>;
+  update?: UpdateFunc<M, any, any>;
 }
 
 export type SaveStatusOptions = "before" | "rightAfter" | "after";
@@ -95,6 +100,7 @@ export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
   private noRawUpdate: boolean;
   focusFunc: EventFunc<M, any, any> | null;
   blurFunc: EventFunc<M, any, any> | null;
+  updateFunc: UpdateFunc<M, any, any> | null;
 
   constructor(
     public form: Form<M, D>,
@@ -141,6 +147,7 @@ export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
       this.validationPauseDuration = 0;
       this.focusFunc = null;
       this.blurFunc = null;
+      this.updateFunc = null;
     } else {
       this.saveFunc = options.save ? options.save : defaultSaveFunc;
       this.isDisabledFunc = options.isDisabled
@@ -169,6 +176,7 @@ export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
       this.validationPauseDuration = validation.pauseDuration || 0;
       this.focusFunc = options.focus ? options.focus : null;
       this.blurFunc = options.blur ? options.blur : null;
+      this.updateFunc = options.update ? options.update : null;
     }
   }
 

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -2252,6 +2252,42 @@ test("blur hook", async () => {
   expect(fooField2.inputProps.onBlur).toBeUndefined();
 });
 
+test("update hook", async () => {
+  const M = types.model("M", {
+    foo: types.string,
+    bar: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string),
+    bar: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO", bar: "BAR" });
+
+  const updated: any[] = [];
+
+  const state = form.state(o, {
+    update: accessor => {
+      updated.push({
+        raw: accessor.raw,
+        value: accessor.value,
+        name: accessor.name
+      });
+    }
+  });
+
+  const fooField = state.field("foo");
+  const barField = state.field("bar");
+  await fooField.setRaw("FOO!");
+  await barField.setRaw("BAR!");
+
+  expect(updated).toEqual([
+    { name: "foo", raw: "FOO!", value: "FOO!" },
+    { name: "bar", raw: "BAR!", value: "BAR!" }
+  ]);
+});
+
 test("string is trimmed", async () => {
   const M = types.model("M", {
     foo: types.string


### PR DESCRIPTION
Add an 'update' hook to the form state. This way we can track when a form is changed (that passes the client-side validation, including the required check).