### PR TITLE
Decimal maybe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 0.24.1
+
+-   Fix a bug where `converters.maybe(converters.decimal())` wasn't doing the
+    right thing. Now the empty decimal will result in the null value.
+
 # 0.24.0
 
 -   Implement a `update` hook on the state options that is called when a field is

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -160,7 +160,7 @@ function maybe<R>(converter: IConverter<R, R>): IConverter<R | null, R | null>;
 function maybe<R, V>(
   converter: Converter<string, V> | IConverter<R, R>
 ): IConverter<string, V | null> | IConverter<R | null, R | null> {
-  if (converter instanceof StringConverter) {
+  if (converter instanceof StringConverter || converter instanceof Decimal) {
     return new StringMaybe(converter);
   }
   return maybeModel(converter as IConverter<R, R>);
@@ -171,7 +171,7 @@ class StringMaybe<V> implements IConverter<string, V | null> {
   defaultControlled = controlled.value;
   neverRequired = false;
 
-  constructor(public converter: StringConverter<V>) {
+  constructor(public converter: IConverter<string, V>) {
     this.emptyRaw = "";
   }
 

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -77,6 +77,13 @@ test("maybe number converter", async () => {
   await check(converters.maybe(converters.number), "", null);
 });
 
+test.only("maybe decimal converter", async () => {
+  await check(converters.maybe(converters.decimal()), "3.14", "3.14");
+  await check(converters.maybe(converters.decimal()), "", null);
+  const c = converters.maybe(converters.decimal());
+  expect(c.render(null)).toEqual("");
+});
+
 test("maybe string converter", async () => {
   await check(converters.maybe(converters.string), "foo", "foo");
   await check(converters.maybe(converters.string), "", null);


### PR DESCRIPTION
converters.maybe(converters.decimal()) wasn't giving a null for the empty string; now it does. We do this by using the maybe string converter, which has the appropriate behavior.