### PR TITLE
ignore required during save

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# 0.25.0
+
+-   You can now pass options into `save()` as an optional argument. Introduced
+    the `ignoreRequired` option which will let save proceed ignoring the
+    `required` setting. Note that this could result in errors if the underlying
+    MST object does not allow you to set null; it only makes sense if you
+    use `types.maybe()` on it and `converters.maybe()` for the field.
+
 # 0.24.1
 
 -   Fix a bug where `converters.maybe(converters.decimal())` wasn't doing the

--- a/README.md
+++ b/README.md
@@ -658,6 +658,23 @@ with `RepeatingFormAccessor`, i.e. the array itself, with `__message__<name>`:
 }
 ```
 
+### Ignoring the required validation
+
+You can pass an option into `save()` to ignore the required validation. This
+can be useful if you have fields which are required in the form yet want allow
+intermediate saves where this required setting is ignored.
+
+Here's how to ignore the `required` validation:
+
+```js
+this.formState.save({ ignoreRequired: true });
+```
+
+This will let `save` proceed even if fields marked as required are not filled
+in. It's up to you to construct the underlying MST model to allow empty values
+(typically with `types.maybe()`) and to let the form accept them too (typically
+with `converters.maybe()`).
+
 ## Controlling validation messages
 
 By default, mstform displays inline validation errors as soon as you

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -8,11 +8,12 @@ import {
   comparer,
   IReactionDisposer
 } from "mobx";
-import { Field, ProcessValue, ValidationMessage } from "./form";
+import { Field, ProcessValue, ValidationMessage, ProcessOptions } from "./form";
 import { FormState } from "./state";
 import { FormAccessor } from "./form-accessor";
 import { currentValidationProps } from "./validation-props";
 import { Accessor } from "./accessor";
+import { ValidateOptions } from "./validate-options";
 
 export class FieldAccessor<M, R, V> {
   name: string;
@@ -215,8 +216,9 @@ export class FieldAccessor<M, R, V> {
     );
   }
 
-  async validate(): Promise<boolean> {
-    await this.setRaw(this.raw);
+  async validate(options?: ValidateOptions): Promise<boolean> {
+    const ignoreRequired = options != null ? options.ignoreRequired : false;
+    await this.setRaw(this.raw, { ignoreRequired });
     return this.isValid;
   }
 
@@ -226,7 +228,7 @@ export class FieldAccessor<M, R, V> {
   }
 
   @action
-  async setRaw(raw: R) {
+  async setRaw(raw: R, options?: ProcessOptions) {
     if (this.state.saveStatus === "rightAfter") {
       this.state.setSaveStatus("after");
     }
@@ -240,7 +242,7 @@ export class FieldAccessor<M, R, V> {
     try {
       // XXX is await correct here? we should await the result
       // later
-      processResult = await this.field.process(raw, this.required);
+      processResult = await this.field.process(raw, this.required, options);
     } catch (e) {
       this.setError("Something went wrong");
       this.setValidating(false);

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -1,4 +1,4 @@
-import { action, computed } from "mobx";
+import { computed } from "mobx";
 import { FormDefinition } from "./form";
 import {
   Accessor,
@@ -7,6 +7,7 @@ import {
   SubFormAccess
 } from "./accessor";
 import { FormAccessor } from "./form-accessor";
+import { ValidateOptions } from "./validate-options";
 
 // a base class that delegates to a form accessor
 export abstract class FormAccessorBase<M, D extends FormDefinition<M>> {
@@ -16,8 +17,8 @@ export abstract class FormAccessorBase<M, D extends FormDefinition<M>> {
     this.formAccessor.initialize();
   }
 
-  async validate(): Promise<boolean> {
-    return this.formAccessor.validate();
+  async validate(options?: ValidateOptions): Promise<boolean> {
+    return this.formAccessor.validate(options);
   }
 
   @computed

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -11,6 +11,7 @@ import { FieldAccessor } from "./field-accessor";
 import { SubFormAccessor } from "./sub-form-accessor";
 import { RepeatingFormAccessor } from "./repeating-form-accessor";
 import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor";
+import { ValidateOptions } from "./validate-options";
 
 export class FormAccessor<M, D extends FormDefinition<M>> {
   private keys: string[];
@@ -42,8 +43,8 @@ export class FormAccessor<M, D extends FormDefinition<M>> {
     this.initialize();
   }
 
-  async validate(): Promise<boolean> {
-    const promises = this.accessors.map(accessor => accessor.validate());
+  async validate(options?: ValidateOptions): Promise<boolean> {
+    const promises = this.accessors.map(accessor => accessor.validate(options));
     const values = await Promise.all(promises);
     values.push(this.errorValue === undefined); // add possible error of the form itself
     return values.every(value => value);

--- a/src/form.ts
+++ b/src/form.ts
@@ -84,6 +84,10 @@ export class ProcessValue<V> {
 
 export type ProcessResponse<V> = ProcessValue<V> | ValidationMessage;
 
+export interface ProcessOptions {
+  ignoreRequired?: boolean;
+}
+
 export class Field<R, V> {
   rawValidators: Validator<R>[];
   validators: Validator<V>[];
@@ -149,11 +153,16 @@ export class Field<R, V> {
     throw new Error("This is a function to enable type introspection");
   }
 
-  async process(raw: R, required: boolean): Promise<ProcessResponse<V>> {
+  async process(
+    raw: R,
+    required: boolean,
+    options?: ProcessOptions
+  ): Promise<ProcessResponse<V>> {
     raw = this.converter.preprocessRaw(raw);
-
+    const ignoreRequired = options != null ? options.ignoreRequired : false;
     if (
       !this.converter.neverRequired &&
+      !ignoreRequired &&
       raw === this.converter.emptyRaw &&
       required
     ) {

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -1,10 +1,11 @@
-import { action, observable, computed } from "mobx";
+import { observable, computed } from "mobx";
 import { applyPatch, resolvePath } from "mobx-state-tree";
 import { FormDefinition, RepeatingForm } from "./form";
 import { FormState } from "./state";
 import { Accessor } from "./accessor";
 import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor";
 import { FormAccessor } from "./form-accessor";
+import { ValidateOptions } from "./validate-options";
 
 export class RepeatingFormAccessor<M, D extends FormDefinition<M>> {
   name: string;
@@ -33,10 +34,10 @@ export class RepeatingFormAccessor<M, D extends FormDefinition<M>> {
     return this.parent.path + "/" + this.name;
   }
 
-  async validate(): Promise<boolean> {
+  async validate(options?: ValidateOptions): Promise<boolean> {
     const promises: Promise<any>[] = [];
     for (const accessor of this.accessors) {
-      promises.push(accessor.validate());
+      promises.push(accessor.validate(options));
     }
     const values = await Promise.all(promises);
     // appending possible error on the repeatingform itself

--- a/src/state.ts
+++ b/src/state.ts
@@ -15,6 +15,7 @@ import { FormAccessor } from "./form-accessor";
 import { RepeatingFormAccessor } from "./repeating-form-accessor";
 import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor";
 import { FormAccessorBase } from "./form-accessor-base";
+import { ValidateOptions } from "./validate-options";
 
 export interface FieldAccessorAllows {
   (fieldAccessor: FieldAccessor<any, any, any>): boolean;
@@ -267,8 +268,8 @@ export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
   }
 
   @action
-  async save(): Promise<boolean> {
-    const isValid = await this.validate();
+  async save(options?: ValidateOptions): Promise<boolean> {
+    const isValid = await this.validate(options);
     this.setSaveStatus("rightAfter");
     if (!isValid) {
       return false;

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -3,6 +3,7 @@ import { FormDefinition } from "./form";
 import { FormState } from "./state";
 import { FormAccessor } from "./form-accessor";
 import { FormAccessorBase } from "./form-accessor-base";
+import { ValidateOptions } from "./validate-options";
 
 export class SubFormAccessor<
   M,
@@ -25,8 +26,8 @@ export class SubFormAccessor<
     // no op
   }
 
-  async validate(): Promise<boolean> {
-    const promises = this.accessors.map(accessor => accessor.validate());
+  async validate(options?: ValidateOptions): Promise<boolean> {
+    const promises = this.accessors.map(accessor => accessor.validate(options));
     const values = await Promise.all(promises);
     values.push(this.errorValue === undefined);
     return values.every(value => value);

--- a/src/validate-options.ts
+++ b/src/validate-options.ts
@@ -1,0 +1,3 @@
+export interface ValidateOptions {
+  ignoreRequired?: boolean;
+}

--- a/test/ignore.test.ts
+++ b/test/ignore.test.ts
@@ -1,0 +1,70 @@
+import { configure } from "mobx";
+import { types } from "mobx-state-tree";
+import { Field, Form, converters } from "../src";
+
+// "strict" leads to trouble during initialization.
+configure({ enforceActions: true });
+
+test("setRaw with required ignore", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string, {
+      required: true
+    })
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const state = form.state(o);
+  const field = state.field("foo");
+
+  await field.setRaw("");
+  expect(field.value).toEqual("FOO");
+
+  await field.setRaw("", { ignoreRequired: true });
+  expect(field.value).toEqual("");
+  expect(o.foo).toEqual("");
+});
+
+test("FormState can be saved ignoring required", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string, { required: true })
+  });
+
+  let saved = false;
+
+  async function save(data: any) {
+    saved = true;
+    return null;
+  }
+
+  const state = form.state(o, { save });
+
+  const field = state.field("foo");
+
+  // we set the raw to the empty string even though it's required
+  await field.setRaw("");
+  expect(field.error).toEqual("Required");
+  expect(o.foo).toEqual("FOO");
+
+  // now we save, ignoring required
+  const saveResult = await state.save({ ignoreRequired: true });
+  expect(field.error).toBeUndefined();
+  expect(o.foo).toEqual("");
+  expect(saveResult).toBeTruthy();
+  expect(saved).toBeTruthy();
+
+  // but saving again without ignoreRequired will be an error
+  const saveResult1 = await state.save();
+  expect(saveResult1).toBeFalsy();
+  expect(field.error).toEqual("Required");
+});


### PR DESCRIPTION
We have the ability to ignore the 'required' validation during save now. This lets us support intermediate saves that succeed though not everything is filled in that's required yet.