### PR TITLE
Ignore get error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,17 @@
 # 0.25.0
 
--   You can now pass options into `save()` as an optional argument. Introduced
-    the `ignoreRequired` option which will let save proceed ignoring the
+-   You can now pass options into `save()` as an optional argument to ignore
+    certain validation behavior. This way you can allow intermediate saves that
+    ignore aspects of validation while retaining full validation before the
+    "final" save.
+
+-   Introduced the `ignoreRequired` save option which make save ignore the
     `required` setting. Note that this could result in errors if the underlying
-    MST object does not allow you to set null; it only makes sense if you
-    use `types.maybe()` on it and `converters.maybe()` for the field.
+    MST object does not allow you to set null; it only makes sense if you use
+    `types.maybe()` on it and `converters.maybe()` for the field.
+
+-   Introduced the `ignoreGetError` save option which makes save ignore any
+    external errors introduced by the `getError` hook.
 
 # 0.24.1
 

--- a/README.md
+++ b/README.md
@@ -670,10 +670,22 @@ Here's how to ignore the `required` validation:
 this.formState.save({ ignoreRequired: true });
 ```
 
-This will let `save` proceed even if fields marked as required are not filled
+This lets `save` proceed even if fields marked as required are not filled
 in. It's up to you to construct the underlying MST model to allow empty values
 (typically with `types.maybe()`) and to let the form accept them too (typically
 with `converters.maybe()`).
+
+### Ignoring the `getError` hook
+
+You can also ignore the `getError` validation during save:
+
+```js
+this.formState.save({ ignoreGetError: true });
+```
+
+This lets `save` proceed even though there are still external validation
+errors. `save` still is blocked when you have an internal validation error -- a
+raw value that cannot be successfully converted.
 
 ## Controlling validation messages
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "0.24.1",
+    "version": "0.25.0",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -218,8 +218,18 @@ export class FieldAccessor<M, R, V> {
 
   async validate(options?: ValidateOptions): Promise<boolean> {
     const ignoreRequired = options != null ? options.ignoreRequired : false;
+    const ignoreGetError = options != null ? options.ignoreGetError : false;
     await this.setRaw(this.raw, { ignoreRequired });
+    if (ignoreGetError) {
+      return this.isInternallyValid;
+    }
     return this.isValid;
+  }
+
+  @computed
+  get isInternallyValid(): boolean {
+    // is internally valid even if getError gives an error
+    return this._error === undefined;
   }
 
   @computed

--- a/src/state.ts
+++ b/src/state.ts
@@ -274,9 +274,7 @@ export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
     if (!isValid) {
       return false;
     }
-    let errors;
-
-    errors = await this.saveFunc(this.node);
+    const errors = await this.saveFunc(this.node);
     if (errors != null) {
       this.setErrors(errors);
       return false;

--- a/src/validate-options.ts
+++ b/src/validate-options.ts
@@ -1,3 +1,4 @@
 export interface ValidateOptions {
   ignoreRequired?: boolean;
+  ignoreGetError?: boolean;
 }


### PR DESCRIPTION
This introduces an option that allows you to ignore getError when you do a save. Note that you should review this only after https://github.com/isprojects/mstform/pull/38 has landed (as that will shrink this diff -- I built on the work introduced there).