### PR TITLE
Fix issue with ignoreGetError.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.25.1
+
+-   `ignoreGetError` wasn't ignoring non-field errors properly. Fixed now.
+
 # 0.25.0
 
 -   You can now pass options into `save()` as an optional argument to ignore

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -46,7 +46,10 @@ export class FormAccessor<M, D extends FormDefinition<M>> {
   async validate(options?: ValidateOptions): Promise<boolean> {
     const promises = this.accessors.map(accessor => accessor.validate(options));
     const values = await Promise.all(promises);
-    values.push(this.errorValue === undefined); // add possible error of the form itself
+    const ignoreGetError = options != null ? options.ignoreGetError : false;
+    if (!ignoreGetError) {
+      values.push(this.errorValue === undefined); // add possible error of the form itself
+    }
     return values.every(value => value);
   }
 

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -41,7 +41,10 @@ export class RepeatingFormAccessor<M, D extends FormDefinition<M>> {
     }
     const values = await Promise.all(promises);
     // appending possible error on the repeatingform itself
-    values.push(this.errorValue === undefined);
+    const ignoreGetError = options != null ? options.ignoreGetError : false;
+    if (!ignoreGetError) {
+      values.push(this.errorValue === undefined);
+    }
     return values.every(value => value);
   }
 

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -29,7 +29,10 @@ export class SubFormAccessor<
   async validate(options?: ValidateOptions): Promise<boolean> {
     const promises = this.accessors.map(accessor => accessor.validate(options));
     const values = await Promise.all(promises);
-    values.push(this.errorValue === undefined);
+    const ignoreGetError = options != null ? options.ignoreGetError : false;
+    if (!ignoreGetError) {
+      values.push(this.errorValue === undefined);
+    }
     return values.every(value => value);
   }
 


### PR DESCRIPTION
Fix a bug where ignoreGetError wasn't ignoring errors for non-field errors.