### PR TITLE
New groups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+# 0.27.0
+
+-   Made the internal typing more complex. Should not affect (or improve) the
+    typing of the various access functions (`.field()`, `.repeatingForm`, etc)
+
+-   Introduced the groups system. This is a reintroduction of the groups
+    concept originally added to 0.12 and removed again in 0.15 as it was
+    incompatible with a big refactoring.
+
+    You can now pass a second argument to `Form`, `RepeatingForm` and `SubForm`
+    with a group definition. You can access these with `.group` accessor
+    that exists on form accessors.
+
 # 0.26.0
 
 -   Better specified a few types in `SubFormAccessor`, `RepeatingFormAccessor`
@@ -98,7 +111,7 @@
 
 # 0.17.1
 
--   When a field is `neverRequired` then we want the 'required' property
+-   When a field is `neverRequired` then we want the 'required' propertGroupy
     to be false, no matter what.
 
 # 0.17.0

--- a/README.md
+++ b/README.md
@@ -822,6 +822,70 @@ const state = form.state(o, {
 Note that you have to use the second `value` argument to get the value to use
 to validate, as `accessor.value` still has the old value.
 
+## Validation groups
+
+It can be useful to consider the validation status of a whole set of related
+fields, without considering the validation status of the whole form. In a UI
+you can then indicate that part of the form is invalid, which is especially
+useful if the form is not visible in its entirety, for instance if is spread
+out across tabs or a menu.
+
+You can define validation groups with a second parameter you pass into `Form`,
+`SubForm` or `RepeatingForm`:
+
+```js
+const M = types.model("M", {
+    a: types.string,
+    b: types.string,
+    c: types.string
+});
+
+const form = new Form(
+    M,
+    {
+        a: new Field(converters.string),
+        b: new Field(converters.string),
+        c: new Field(converters.string)
+    },
+    {
+        one: new Group({ include: ["a", "b"] }),
+        two: new Group({ include: ["c"] })
+    }
+);
+```
+
+Here we define two groups, `one` and `two`. Group `one` is valid only if `a`
+and `b` are valid. Group `two` is valid only if `c` is valid.
+
+You can access a group on the state or form accessor and check its `isValid`
+property:
+
+```js
+const first = state.group("first");
+if (first.isValid) {
+    // only executed if a and b are valid
+}
+```
+
+When you define a group you can pass `exclude` instead of `include`:
+
+```js
+const form = new Form(
+    M,
+    {
+        a: new Field(converters.string),
+        b: new Field(converters.string),
+        c: new Field(converters.string)
+    },
+    {
+        one: new Group({ exclude: ["c"] })
+    }
+);
+```
+
+Group `one` now includes all accessors except `c`, and therefore `a` and `b` as
+well.
+
 ## Derived values
 
 The value of some fields depends on the value of other fields; you can express

--- a/demo/component.tsx
+++ b/demo/component.tsx
@@ -37,7 +37,7 @@ const form = new Form(M, {
 });
 
 type InlineErrorProps = {
-  field?: FieldAccessor<any, any, any>;
+  field?: FieldAccessor<any, any>;
 };
 
 @observer
@@ -56,7 +56,7 @@ class InlineError extends Component<InlineErrorProps> {
 @observer
 export class MyInput extends Component<{
   type: string;
-  field: FieldAccessor<any, any, any>;
+  field: FieldAccessor<any, any>;
 }> {
   render() {
     const { type, field } = this.props;

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -17,7 +17,7 @@ import { GroupAccessor } from "./group-accessor";
 // whether a form is valid
 export type Accessor =
   | FormAccessor<any, any, any>
-  | FieldAccessor<any, any, any>
+  | FieldAccessor<any, any>
   | RepeatingFormAccessor<any, any, any>
   | RepeatingFormIndexedAccessor<any, any, any>
   | SubFormAccessor<any, any, any>;
@@ -26,7 +26,7 @@ export type FieldAccess<
   M,
   D extends FormDefinition<M>,
   K extends keyof D
-> = FieldAccessor<M, RawType<D[K]>, D[K]>;
+> = FieldAccessor<RawType<D[K]>, D[K]>;
 
 export type RepeatingFormAccess<
   M,

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -1,8 +1,9 @@
 import {
-  ArrayEntryType,
   FormDefinition,
   RepeatingFormDefinitionType,
+  RepeatingFormGroupDefinitionType,
   SubFormDefinitionType,
+  SubFormGroupDefinitionType,
   RawType
 } from "./form";
 import { FieldAccessor } from "./field-accessor";
@@ -30,11 +31,17 @@ export type FieldAccess<
 export type RepeatingFormAccess<
   D extends FormDefinition<any>,
   K extends keyof D
-> = RepeatingFormAccessor<RepeatingFormDefinitionType<D[K]>, any>;
+> = RepeatingFormAccessor<
+  RepeatingFormDefinitionType<D[K]>,
+  RepeatingFormGroupDefinitionType<D[K]>
+>;
 
 export type SubFormAccess<
   D extends FormDefinition<any>,
   K extends keyof D
-> = SubFormAccessor<SubFormDefinitionType<D[K]>, any>;
+> = SubFormAccessor<
+  SubFormDefinitionType<D[K]>,
+  SubFormGroupDefinitionType<D[K]>
+>;
 
 export type GroupAccess<M, D extends FormDefinition<M>> = GroupAccessor<M, D>;

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -19,7 +19,7 @@ export type Accessor =
   | FormAccessor<any, any>
   | FieldAccessor<any, any>
   | RepeatingFormAccessor<any, any>
-  | RepeatingFormIndexedAccessor<any, any, any>
+  | RepeatingFormIndexedAccessor<any, any>
   | SubFormAccessor<any, any, any>;
 
 export type FieldAccess<

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -16,7 +16,7 @@ import { GroupAccessor } from "./group-accessor";
 // as we never need to walk the group accessors to see
 // whether a form is valid
 export type Accessor =
-  | FormAccessor<any, any, any>
+  | FormAccessor<any, any>
   | FieldAccessor<any, any>
   | RepeatingFormAccessor<any, any, any>
   | RepeatingFormIndexedAccessor<any, any, any>

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -20,7 +20,7 @@ export type Accessor =
   | FieldAccessor<any, any>
   | RepeatingFormAccessor<any, any>
   | RepeatingFormIndexedAccessor<any, any>
-  | SubFormAccessor<any, any, any>;
+  | SubFormAccessor<any, any>;
 
 export type FieldAccess<
   D extends FormDefinition<any>,
@@ -35,6 +35,6 @@ export type RepeatingFormAccess<
 export type SubFormAccess<
   D extends FormDefinition<any>,
   K extends keyof D
-> = SubFormAccessor<D[K], SubFormDefinitionType<D[K]>, any>;
+> = SubFormAccessor<SubFormDefinitionType<D[K]>, any>;
 
 export type GroupAccess<M, D extends FormDefinition<M>> = GroupAccessor<M, D>;

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -1,14 +1,4 @@
 import {
-  action,
-  observable,
-  computed,
-  isObservable,
-  toJS,
-  reaction,
-  comparer,
-  IReactionDisposer
-} from "mobx";
-import {
   ArrayEntryType,
   FormDefinition,
   RepeatingFormDefinitionType,
@@ -20,13 +10,17 @@ import { FormAccessor } from "./form-accessor";
 import { RepeatingFormAccessor } from "./repeating-form-accessor";
 import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor";
 import { SubFormAccessor } from "./sub-form-accessor";
+import { GroupAccessor } from "./group-accessor";
 
+// group access is deliberately not in Accessor
+// as we never need to walk the group accessors to see
+// whether a form is valid
 export type Accessor =
-  | FormAccessor<any, any>
+  | FormAccessor<any, any, any>
   | FieldAccessor<any, any, any>
-  | RepeatingFormAccessor<any, any>
-  | RepeatingFormIndexedAccessor<any, any>
-  | SubFormAccessor<any, any>;
+  | RepeatingFormAccessor<any, any, any>
+  | RepeatingFormIndexedAccessor<any, any, any>
+  | SubFormAccessor<any, any, any>;
 
 export type FieldAccess<
   M,
@@ -40,11 +34,14 @@ export type RepeatingFormAccess<
   K extends keyof M
 > = RepeatingFormAccessor<
   ArrayEntryType<M[K]>,
-  RepeatingFormDefinitionType<D[K]>
+  RepeatingFormDefinitionType<D[K]>,
+  any
 >;
 
 export type SubFormAccess<
   M,
   D extends FormDefinition<M>,
   K extends keyof M
-> = SubFormAccessor<M[K], SubFormDefinitionType<D[K]>>;
+> = SubFormAccessor<M[K], SubFormDefinitionType<D[K]>, any>;
+
+export type GroupAccess<M, D extends FormDefinition<M>> = GroupAccessor<M, D>;

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -25,15 +25,15 @@ export type Accessor =
 export type FieldAccess<
   M,
   D extends FormDefinition<M>,
-  K extends keyof M
-> = FieldAccessor<M, RawType<D[K]>, M[K]>;
+  K extends keyof D
+> = FieldAccessor<M, RawType<D[K]>, D[K]>;
 
 export type RepeatingFormAccess<
   M,
   D extends FormDefinition<M>,
-  K extends keyof M
+  K extends keyof D
 > = RepeatingFormAccessor<
-  ArrayEntryType<M[K]>,
+  ArrayEntryType<D[K]>,
   RepeatingFormDefinitionType<D[K]>,
   any
 >;
@@ -41,7 +41,7 @@ export type RepeatingFormAccess<
 export type SubFormAccess<
   M,
   D extends FormDefinition<M>,
-  K extends keyof M
-> = SubFormAccessor<M[K], SubFormDefinitionType<D[K]>, any>;
+  K extends keyof D
+> = SubFormAccessor<D[K], SubFormDefinitionType<D[K]>, any>;
 
 export type GroupAccess<M, D extends FormDefinition<M>> = GroupAccessor<M, D>;

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -23,14 +23,12 @@ export type Accessor =
   | SubFormAccessor<any, any, any>;
 
 export type FieldAccess<
-  M,
-  D extends FormDefinition<M>,
+  D extends FormDefinition<any>,
   K extends keyof D
 > = FieldAccessor<RawType<D[K]>, D[K]>;
 
 export type RepeatingFormAccess<
-  M,
-  D extends FormDefinition<M>,
+  D extends FormDefinition<any>,
   K extends keyof D
 > = RepeatingFormAccessor<
   ArrayEntryType<D[K]>,
@@ -39,8 +37,7 @@ export type RepeatingFormAccess<
 >;
 
 export type SubFormAccess<
-  M,
-  D extends FormDefinition<M>,
+  D extends FormDefinition<any>,
   K extends keyof D
 > = SubFormAccessor<D[K], SubFormDefinitionType<D[K]>, any>;
 

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -18,7 +18,7 @@ import { GroupAccessor } from "./group-accessor";
 export type Accessor =
   | FormAccessor<any, any>
   | FieldAccessor<any, any>
-  | RepeatingFormAccessor<any, any, any>
+  | RepeatingFormAccessor<any, any>
   | RepeatingFormIndexedAccessor<any, any, any>
   | SubFormAccessor<any, any, any>;
 
@@ -30,11 +30,7 @@ export type FieldAccess<
 export type RepeatingFormAccess<
   D extends FormDefinition<any>,
   K extends keyof D
-> = RepeatingFormAccessor<
-  ArrayEntryType<D[K]>,
-  RepeatingFormDefinitionType<D[K]>,
-  any
->;
+> = RepeatingFormAccessor<RepeatingFormDefinitionType<D[K]>, any>;
 
 export type SubFormAccess<
   D extends FormDefinition<any>,

--- a/src/controlled.ts
+++ b/src/controlled.ts
@@ -1,7 +1,7 @@
 import { FieldAccessor } from "./field-accessor";
 
 export interface Controlled {
-  (accessor: FieldAccessor<any, any, any>): any;
+  (accessor: FieldAccessor<any, any>): any;
 }
 
 const value: Controlled = accessor => {

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -83,6 +83,8 @@ export class FieldAccessor<R, V> {
     this._disposer = disposer;
   }
 
+  // XXX I think this should become private (_node), unless I
+  // guarantee the type without a lot of complication
   @computed
   get node(): any {
     // XXX it's possible for this to be called for a node that has since

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -33,9 +33,9 @@ export class FieldAccessor<M, R, V> {
   _disposer: IReactionDisposer | undefined;
 
   constructor(
-    public state: FormState<any, any>,
+    public state: FormState<any, any, any>,
     public field: Field<R, V>,
-    public parent: FormAccessor<any, any>,
+    public parent: FormAccessor<any, any, any>,
     name: string
   ) {
     this.name = name;

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -15,7 +15,7 @@ import { currentValidationProps } from "./validation-props";
 import { Accessor } from "./accessor";
 import { ValidateOptions } from "./validate-options";
 
-export class FieldAccessor<M, R, V> {
+export class FieldAccessor<R, V> {
   name: string;
 
   @observable
@@ -84,7 +84,7 @@ export class FieldAccessor<M, R, V> {
   }
 
   @computed
-  get node(): M | undefined {
+  get node(): any {
     // XXX it's possible for this to be called for a node that has since
     // been removed. It's not ideal but we return undefined in such a case.
     try {

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -35,7 +35,7 @@ export class FieldAccessor<R, V> {
   constructor(
     public state: FormState<any, any, any>,
     public field: Field<R, V>,
-    public parent: FormAccessor<any, any, any>,
+    public parent: FormAccessor<any, any>,
     name: string
   ) {
     this.name = name;

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -13,7 +13,7 @@ import { ValidateOptions } from "./validate-options";
 // a base class that delegates to a form accessor
 export abstract class FormAccessorBase<
   D extends FormDefinition<any>,
-  G extends GroupDefinition<any, D>
+  G extends GroupDefinition<D>
 > {
   abstract formAccessor: FormAccessor<D, G>;
 

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -12,11 +12,10 @@ import { ValidateOptions } from "./validate-options";
 
 // a base class that delegates to a form accessor
 export abstract class FormAccessorBase<
-  M,
-  D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  D extends FormDefinition<any>,
+  G extends GroupDefinition<any, D>
 > {
-  abstract formAccessor: FormAccessor<M, D, G>;
+  abstract formAccessor: FormAccessor<D, G>;
 
   initialize() {
     this.formAccessor.initialize();
@@ -77,7 +76,7 @@ export abstract class FormAccessorBase<
     return this.formAccessor.subForm(name);
   }
 
-  group<K extends keyof G>(name: K): GroupAccess<M, D> {
+  group<K extends keyof G>(name: K): GroupAccess<any, D> {
     return this.formAccessor.group(name);
   }
 

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -1,17 +1,22 @@
 import { computed } from "mobx";
-import { FormDefinition } from "./form";
+import { FormDefinition, GroupDefinition } from "./form";
 import {
   Accessor,
   FieldAccess,
   RepeatingFormAccess,
-  SubFormAccess
+  SubFormAccess,
+  GroupAccess
 } from "./accessor";
 import { FormAccessor } from "./form-accessor";
 import { ValidateOptions } from "./validate-options";
 
 // a base class that delegates to a form accessor
-export abstract class FormAccessorBase<M, D extends FormDefinition<M>> {
-  abstract formAccessor: FormAccessor<M, D>;
+export abstract class FormAccessorBase<
+  M,
+  D extends FormDefinition<M>,
+  G extends GroupDefinition<M, D>
+> {
+  abstract formAccessor: FormAccessor<M, D, G>;
 
   initialize() {
     this.formAccessor.initialize();
@@ -70,6 +75,10 @@ export abstract class FormAccessorBase<M, D extends FormDefinition<M>> {
 
   subForm<K extends keyof M>(name: K): SubFormAccess<M, D, K> {
     return this.formAccessor.subForm(name);
+  }
+
+  group<K extends keyof G>(name: K): GroupAccess<M, D> {
+    return this.formAccessor.group(name);
   }
 
   @computed

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -65,15 +65,15 @@ export abstract class FormAccessorBase<
     return this.formAccessor.accessBySteps(steps);
   }
 
-  field<K extends keyof D>(name: K): FieldAccess<M, D, K> {
+  field<K extends keyof D>(name: K): FieldAccess<D, K> {
     return this.formAccessor.field(name);
   }
 
-  repeatingForm<K extends keyof D>(name: K): RepeatingFormAccess<M, D, K> {
+  repeatingForm<K extends keyof D>(name: K): RepeatingFormAccess<D, K> {
     return this.formAccessor.repeatingForm(name);
   }
 
-  subForm<K extends keyof D>(name: K): SubFormAccess<M, D, K> {
+  subForm<K extends keyof D>(name: K): SubFormAccess<D, K> {
     return this.formAccessor.subForm(name);
   }
 

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -65,15 +65,15 @@ export abstract class FormAccessorBase<
     return this.formAccessor.accessBySteps(steps);
   }
 
-  field<K extends keyof M>(name: K): FieldAccess<M, D, K> {
+  field<K extends keyof D>(name: K): FieldAccess<M, D, K> {
     return this.formAccessor.field(name);
   }
 
-  repeatingForm<K extends keyof M>(name: K): RepeatingFormAccess<M, D, K> {
+  repeatingForm<K extends keyof D>(name: K): RepeatingFormAccess<M, D, K> {
     return this.formAccessor.repeatingForm(name);
   }
 
-  subForm<K extends keyof M>(name: K): SubFormAccess<M, D, K> {
+  subForm<K extends keyof D>(name: K): SubFormAccess<M, D, K> {
     return this.formAccessor.subForm(name);
   }
 

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -26,7 +26,7 @@ export class FormAccessor<
   D extends FormDefinition<any>,
   G extends GroupDefinition<D>
 > {
-  private keys: string[];
+  public keys: (keyof D)[];
   fieldAccessors: Map<keyof D, FieldAccessor<any, any>> = observable.map();
   repeatingFormAccessors: Map<
     keyof D,
@@ -48,11 +48,9 @@ export class FormAccessor<
       | RepeatingFormAccessor<any, any>
       | RepeatingFormIndexedAccessor<any, any>
       | null,
-    addMode: boolean,
-    public allowedKeys?: string[]
+    addMode: boolean
   ) {
-    this.keys =
-      allowedKeys != null ? allowedKeys : Object.keys(this.definition);
+    this.keys = Object.keys(this.definition);
     this._addMode = addMode;
     this.initialize();
   }

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -194,7 +194,7 @@ export class FormAccessor<
     this.fieldAccessors.set(name, result);
   }
 
-  field<K extends keyof D>(name: K): FieldAccess<M, D, K> {
+  field<K extends keyof D>(name: K): FieldAccess<D, K> {
     const accessor = this.fieldAccessors.get(name);
     if (accessor == null) {
       throw new Error(`${name} is not a Field`);
@@ -216,7 +216,7 @@ export class FormAccessor<
     result.initialize();
   }
 
-  repeatingForm<K extends keyof D>(name: K): RepeatingFormAccess<M, D, K> {
+  repeatingForm<K extends keyof D>(name: K): RepeatingFormAccess<D, K> {
     const accessor = this.repeatingFormAccessors.get(name);
     if (accessor == null) {
       throw new Error(`${name} is not a RepeatingForm`);
@@ -236,7 +236,7 @@ export class FormAccessor<
     result.initialize();
   }
 
-  subForm<K extends keyof D>(name: K): SubFormAccess<M, D, K> {
+  subForm<K extends keyof D>(name: K): SubFormAccess<D, K> {
     const accessor = this.subFormAccessors.get(name);
     if (accessor == null) {
       throw new Error(`${name} is not a SubForm`);

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -200,7 +200,7 @@ export class FormAccessor<
 
   createRepeatingForm<K extends keyof D>(
     name: K,
-    repeatingForm: RepeatingForm<any, any, any>
+    repeatingForm: RepeatingForm<any, any>
   ) {
     const result = new RepeatingFormAccessor(
       this.state,

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -28,13 +28,13 @@ export class FormAccessor<
   G extends GroupDefinition<M, D>
 > {
   private keys: string[];
-  fieldAccessors: Map<keyof M, FieldAccessor<any, any, any>> = observable.map();
+  fieldAccessors: Map<keyof D, FieldAccessor<any, any, any>> = observable.map();
   repeatingFormAccessors: Map<
-    keyof M,
+    keyof D,
     RepeatingFormAccessor<any, any, any>
   > = observable.map();
   subFormAccessors: Map<
-    keyof M,
+    keyof D,
     SubFormAccessor<any, any, any>
   > = observable.map();
   groupAccessors: Map<keyof G, GroupAccessor<any, any>> = observable.map();
@@ -140,13 +140,13 @@ export class FormAccessor<
 
     // XXX catching errors isn't ideal
     try {
-      return this.field(name as keyof M);
+      return this.field(name as keyof D);
     } catch {
       try {
-        return this.repeatingForm(name as keyof M);
+        return this.repeatingForm(name as keyof D);
       } catch {
         try {
-          return this.subForm(name as keyof M);
+          return this.subForm(name as keyof D);
         } catch {
           return undefined;
         }
@@ -173,11 +173,11 @@ export class FormAccessor<
     this.keys.forEach(key => {
       const entry = this.definition[key];
       if (entry instanceof Field) {
-        this.createField(key as keyof M, entry);
+        this.createField(key as keyof D, entry);
       } else if (entry instanceof RepeatingForm) {
-        this.createRepeatingForm(key as keyof M, entry);
+        this.createRepeatingForm(key as keyof D, entry);
       } else if (entry instanceof SubForm) {
-        this.createSubForm(key as keyof M, entry);
+        this.createSubForm(key as keyof D, entry);
       }
     });
     if (this.groupDefinition != null) {
@@ -189,12 +189,12 @@ export class FormAccessor<
     }
   }
 
-  createField<K extends keyof M>(name: K, field: Field<any, any>) {
+  createField<K extends keyof D>(name: K, field: Field<any, any>) {
     const result = new FieldAccessor(this.state, field, this, name as string);
     this.fieldAccessors.set(name, result);
   }
 
-  field<K extends keyof M>(name: K): FieldAccess<M, D, K> {
+  field<K extends keyof D>(name: K): FieldAccess<M, D, K> {
     const accessor = this.fieldAccessors.get(name);
     if (accessor == null) {
       throw new Error(`${name} is not a Field`);
@@ -202,7 +202,7 @@ export class FormAccessor<
     return accessor;
   }
 
-  createRepeatingForm<K extends keyof M>(
+  createRepeatingForm<K extends keyof D>(
     name: K,
     repeatingForm: RepeatingForm<any, any, any>
   ) {
@@ -216,7 +216,7 @@ export class FormAccessor<
     result.initialize();
   }
 
-  repeatingForm<K extends keyof M>(name: K): RepeatingFormAccess<M, D, K> {
+  repeatingForm<K extends keyof D>(name: K): RepeatingFormAccess<M, D, K> {
     const accessor = this.repeatingFormAccessors.get(name);
     if (accessor == null) {
       throw new Error(`${name} is not a RepeatingForm`);
@@ -224,7 +224,7 @@ export class FormAccessor<
     return accessor;
   }
 
-  createSubForm<K extends keyof M>(name: K, subForm: SubForm<any, any, any>) {
+  createSubForm<K extends keyof D>(name: K, subForm: SubForm<any, any, any>) {
     const result = new SubFormAccessor(
       this.state,
       subForm.definition,
@@ -236,7 +236,7 @@ export class FormAccessor<
     result.initialize();
   }
 
-  subForm<K extends keyof M>(name: K): SubFormAccess<M, D, K> {
+  subForm<K extends keyof D>(name: K): SubFormAccess<M, D, K> {
     const accessor = this.subFormAccessors.get(name);
     if (accessor == null) {
       throw new Error(`${name} is not a SubForm`);

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -95,11 +95,11 @@ export class FormAccessor<
     this.keys.forEach(key => {
       const entry = this.definition[key];
       if (entry instanceof Field) {
-        result.push(this.field(key as keyof M));
+        result.push(this.field(key as keyof D));
       } else if (entry instanceof RepeatingForm) {
-        result.push(this.repeatingForm(key as keyof M));
+        result.push(this.repeatingForm(key as keyof D));
       } else if (entry instanceof SubForm) {
-        result.push(this.subForm(key as keyof M));
+        result.push(this.subForm(key as keyof D));
       }
     });
     return result;

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -49,7 +49,7 @@ export class FormAccessor<
       | FormAccessor<any, any>
       | SubFormAccessor<any, any, any>
       | RepeatingFormAccessor<any, any>
-      | RepeatingFormIndexedAccessor<any, any, any>
+      | RepeatingFormIndexedAccessor<any, any>
       | null,
     addMode: boolean,
     public allowedKeys?: string[]

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -30,7 +30,7 @@ export class FormAccessor<
   fieldAccessors: Map<keyof D, FieldAccessor<any, any>> = observable.map();
   repeatingFormAccessors: Map<
     keyof D,
-    RepeatingFormAccessor<any, any, any>
+    RepeatingFormAccessor<any, any>
   > = observable.map();
   subFormAccessors: Map<
     keyof D,
@@ -48,7 +48,7 @@ export class FormAccessor<
     public parent:
       | FormAccessor<any, any>
       | SubFormAccessor<any, any, any>
-      | RepeatingFormAccessor<any, any, any>
+      | RepeatingFormAccessor<any, any>
       | RepeatingFormIndexedAccessor<any, any, any>
       | null,
     addMode: boolean,

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -23,9 +23,8 @@ import { GroupAccessor } from "./group-accessor";
 import { ValidateOptions } from "./validate-options";
 
 export class FormAccessor<
-  M,
-  D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  D extends FormDefinition<any>,
+  G extends GroupDefinition<any, D>
 > {
   private keys: string[];
   fieldAccessors: Map<keyof D, FieldAccessor<any, any>> = observable.map();
@@ -43,11 +42,11 @@ export class FormAccessor<
   _addMode: boolean;
 
   constructor(
-    public state: FormState<M, D, G>,
+    public state: FormState<any, D, G>,
     public definition: any,
     public groupDefinition: any,
     public parent:
-      | FormAccessor<any, any, any>
+      | FormAccessor<any, any>
       | SubFormAccessor<any, any, any>
       | RepeatingFormAccessor<any, any, any>
       | RepeatingFormIndexedAccessor<any, any, any>
@@ -249,7 +248,7 @@ export class FormAccessor<
     this.groupAccessors.set(name, result);
   }
 
-  group<K extends keyof G>(name: K): GroupAccess<M, D> {
+  group<K extends keyof G>(name: K): GroupAccess<any, D> {
     const accessor = this.groupAccessors.get(name);
     if (accessor == null) {
       throw new Error(`${name} is not a Group`);

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -28,7 +28,7 @@ export class FormAccessor<
   G extends GroupDefinition<M, D>
 > {
   private keys: string[];
-  fieldAccessors: Map<keyof D, FieldAccessor<any, any, any>> = observable.map();
+  fieldAccessors: Map<keyof D, FieldAccessor<any, any>> = observable.map();
   repeatingFormAccessors: Map<
     keyof D,
     RepeatingFormAccessor<any, any, any>

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -220,7 +220,7 @@ export class FormAccessor<
     return accessor;
   }
 
-  createSubForm<K extends keyof D>(name: K, subForm: SubForm<any, any, any>) {
+  createSubForm<K extends keyof D>(name: K, subForm: SubForm<any, any>) {
     const result = new SubFormAccessor(
       this.state,
       subForm.definition,

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -24,7 +24,7 @@ import { ValidateOptions } from "./validate-options";
 
 export class FormAccessor<
   D extends FormDefinition<any>,
-  G extends GroupDefinition<any, D>
+  G extends GroupDefinition<D>
 > {
   private keys: string[];
   fieldAccessors: Map<keyof D, FieldAccessor<any, any>> = observable.map();
@@ -240,7 +240,7 @@ export class FormAccessor<
     return accessor;
   }
 
-  createGroup<K extends keyof G>(name: K, group: Group<any, any>) {
+  createGroup<K extends keyof G>(name: K, group: Group<any>) {
     const result = new GroupAccessor(this.state, this.definition, this, group);
     this.groupAccessors.set(name, result);
   }

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -32,10 +32,7 @@ export class FormAccessor<
     keyof D,
     RepeatingFormAccessor<any, any>
   > = observable.map();
-  subFormAccessors: Map<
-    keyof D,
-    SubFormAccessor<any, any, any>
-  > = observable.map();
+  subFormAccessors: Map<keyof D, SubFormAccessor<any, any>> = observable.map();
   groupAccessors: Map<keyof G, GroupAccessor<any, any>> = observable.map();
 
   @observable
@@ -47,7 +44,7 @@ export class FormAccessor<
     public groupDefinition: any,
     public parent:
       | FormAccessor<any, any>
-      | SubFormAccessor<any, any, any>
+      | SubFormAccessor<any, any>
       | RepeatingFormAccessor<any, any>
       | RepeatingFormIndexedAccessor<any, any>
       | null,

--- a/src/form.ts
+++ b/src/form.ts
@@ -28,7 +28,7 @@ export type FormDefinitionEntry<M, K extends keyof M> =
       FormDefinition<ArrayEntryType<M[K]>>,
       any
     >
-  | SubForm<M[K], FormDefinition<M[K]>, GroupDefinition<M[K], any>>;
+  | SubForm<M[K], FormDefinition<M[K]>, GroupDefinition<any>>;
 
 export type FormDefinition<M> = { [K in keyof M]?: FormDefinitionEntry<M, K> };
 
@@ -63,14 +63,14 @@ export interface FieldOptions<R, V> {
   controlled?: Controlled;
 }
 
-export type GroupDefinition<M, D extends FormDefinition<M>> = {
-  [key: string]: Group<M, D>;
+export type GroupDefinition<D extends FormDefinition<any>> = {
+  [key: string]: Group<D>;
 };
 
 export class Form<
   M,
   D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  G extends GroupDefinition<D>
 > {
   constructor(
     public model: IModelType<any, M>,
@@ -90,7 +90,7 @@ export class Form<
 export class SubForm<
   M,
   D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  G extends GroupDefinition<D>
 > {
   constructor(public definition: D, public groupDefinition?: G) {}
 }
@@ -222,16 +222,16 @@ export class Field<R, V> {
 export class RepeatingForm<
   M,
   D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  G extends GroupDefinition<D>
 > {
   constructor(public definition: D, public groupDefinition?: G) {}
 }
 
-export interface GroupOptions<M, D extends FormDefinition<M>> {
+export interface GroupOptions<D extends FormDefinition<any>> {
   include?: (keyof D)[];
   exclude?: (keyof D)[];
 }
 
-export class Group<M, D extends FormDefinition<M>> {
-  constructor(public options: GroupOptions<M, D>) {}
+export class Group<D extends FormDefinition<any>> {
+  constructor(public options: GroupOptions<D>) {}
 }

--- a/src/form.ts
+++ b/src/form.ts
@@ -16,8 +16,19 @@ export type RepeatingFormDefinitionType<T> = T extends RepeatingForm<
   ? D
   : never;
 
+export type RepeatingFormGroupDefinitionType<T> = T extends RepeatingForm<
+  any,
+  infer G
+>
+  ? G
+  : never;
+
 export type SubFormDefinitionType<T> = T extends SubForm<infer D, any>
   ? D
+  : never;
+
+export type SubFormGroupDefinitionType<T> = T extends SubForm<any, infer G>
+  ? G
   : never;
 
 export type FormDefinitionEntry<M, K extends keyof M> =

--- a/src/form.ts
+++ b/src/form.ts
@@ -16,14 +16,14 @@ export type RepeatingFormDefinitionType<T> = T extends RepeatingForm<
   ? D
   : never;
 
-export type SubFormDefinitionType<T> = T extends SubForm<any, infer D, any>
+export type SubFormDefinitionType<T> = T extends SubForm<infer D, any>
   ? D
   : never;
 
 export type FormDefinitionEntry<M, K extends keyof M> =
   | Field<any, M[K]>
   | RepeatingForm<FormDefinition<ArrayEntryType<M[K]>>, any>
-  | SubForm<M[K], FormDefinition<M[K]>, GroupDefinition<any>>;
+  | SubForm<FormDefinition<M[K]>, GroupDefinition<any>>;
 
 export type FormDefinition<M> = { [K in keyof M]?: FormDefinitionEntry<M, K> };
 
@@ -83,8 +83,7 @@ export class Form<
 }
 
 export class SubForm<
-  M,
-  D extends FormDefinition<M>,
+  D extends FormDefinition<any>,
   G extends GroupDefinition<D>
 > {
   constructor(public definition: D, public groupDefinition?: G) {}

--- a/src/form.ts
+++ b/src/form.ts
@@ -33,7 +33,7 @@ export type SubFormGroupDefinitionType<T> = T extends SubForm<any, infer G>
 
 export type FormDefinitionEntry<M, K extends keyof M> =
   | Field<any, M[K]>
-  | RepeatingForm<FormDefinition<ArrayEntryType<M[K]>>, any>
+  | RepeatingForm<FormDefinition<ArrayEntryType<M[K]>>, GroupDefinition<any>>
   | SubForm<FormDefinition<M[K]>, GroupDefinition<any>>;
 
 export type FormDefinition<M> = { [K in keyof M]?: FormDefinitionEntry<M, K> };

--- a/src/form.ts
+++ b/src/form.ts
@@ -10,7 +10,6 @@ export type ArrayEntryType<T> = T extends IObservableArray<infer A> ? A : never;
 export type RawType<F> = F extends Field<infer R, any> ? R : never;
 
 export type RepeatingFormDefinitionType<T> = T extends RepeatingForm<
-  any,
   infer D,
   any
 >
@@ -23,11 +22,7 @@ export type SubFormDefinitionType<T> = T extends SubForm<any, infer D, any>
 
 export type FormDefinitionEntry<M, K extends keyof M> =
   | Field<any, M[K]>
-  | RepeatingForm<
-      ArrayEntryType<M[K]>,
-      FormDefinition<ArrayEntryType<M[K]>>,
-      any
-    >
+  | RepeatingForm<FormDefinition<ArrayEntryType<M[K]>>, any>
   | SubForm<M[K], FormDefinition<M[K]>, GroupDefinition<any>>;
 
 export type FormDefinition<M> = { [K in keyof M]?: FormDefinitionEntry<M, K> };
@@ -220,8 +215,7 @@ export class Field<R, V> {
 }
 
 export class RepeatingForm<
-  M,
-  D extends FormDefinition<M>,
+  D extends FormDefinition<any>,
   G extends GroupDefinition<D>
 > {
   constructor(public definition: D, public groupDefinition?: G) {}

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -8,7 +8,7 @@ export class GroupAccessor<M, D extends FormDefinition<M>> {
     public state: FormState<any, any, any>,
     public definition: D,
     public parent: FormAccessor<any, any>,
-    public group: Group<M, D>
+    public group: Group<D>
   ) {}
 
   @computed

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -14,10 +14,26 @@ export class GroupAccessor<M, D extends FormDefinition<M>> {
   @computed
   get isValid(): boolean {
     const include = this.group.options.include;
-    if (include == null) {
-      return true;
+    const exclude = this.group.options.exclude;
+    if (include != null && exclude != null) {
+      throw new Error("Cannot include and exclude fields at the same time.");
     }
-    return include.every(key => {
+    if (include != null) {
+      return this.isValidForNames(include);
+    }
+    if (exclude != null) {
+      return this.isValidForNames(this.notExcluded(exclude));
+    }
+    throw new Error("Must include or exclude some fields");
+  }
+
+  notExcluded(names: (keyof D)[]): (keyof D)[] {
+    const keys = this.parent.keys as (keyof D)[];
+    return keys.filter(name => !names.includes(name));
+  }
+
+  isValidForNames(names: (keyof D)[]): boolean {
+    return names.every(key => {
       const accessor = this.parent.access(key as string);
       if (accessor == null) {
         return true;

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -1,0 +1,28 @@
+import { computed } from "mobx";
+import { FormDefinition, Group } from "./form";
+import { FormState } from "./state";
+import { FormAccessor } from "./form-accessor";
+
+export class GroupAccessor<M, D extends FormDefinition<M>> {
+  constructor(
+    public state: FormState<any, any, any>,
+    public definition: D,
+    public parent: FormAccessor<any, any, any>,
+    public group: Group<M, D>
+  ) {}
+
+  @computed
+  get isValid(): boolean {
+    const include = this.group.options.include;
+    if (include == null) {
+      return true;
+    }
+    return include.every(key => {
+      const accessor = this.parent.access(key as string);
+      if (accessor == null) {
+        return true;
+      }
+      return accessor.isValid;
+    });
+  }
+}

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -7,7 +7,7 @@ export class GroupAccessor<M, D extends FormDefinition<M>> {
   constructor(
     public state: FormState<any, any, any>,
     public definition: D,
-    public parent: FormAccessor<any, any, any>,
+    public parent: FormAccessor<any, any>,
     public group: Group<M, D>
   ) {}
 

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -79,7 +79,7 @@ export class RepeatingFormAccessor<
     result.initialize();
   }
 
-  index(index: number): RepeatingFormIndexedAccessor<any, D, G> {
+  index(index: number): RepeatingFormIndexedAccessor<D, G> {
     const accessor = this.repeatingFormIndexedAccessors.get(index);
     if (accessor == null) {
       throw new Error(`${index} is not a RepeatingFormIndexedAccessor`);
@@ -93,7 +93,7 @@ export class RepeatingFormAccessor<
   }
 
   @computed
-  get accessors(): RepeatingFormIndexedAccessor<any, D, G>[] {
+  get accessors(): RepeatingFormIndexedAccessor<D, G>[] {
     const result = [];
     for (let index = 0; index < this.length; index++) {
       result.push(this.index(index));
@@ -153,7 +153,7 @@ export class RepeatingFormAccessor<
       return;
     }
     const toDelete: number[] = [];
-    const toInsert: RepeatingFormIndexedAccessor<any, any, any>[] = [];
+    const toInsert: RepeatingFormIndexedAccessor<any, any>[] = [];
 
     accessors.forEach((accessor, i) => {
       if (i <= index) {
@@ -170,7 +170,7 @@ export class RepeatingFormAccessor<
     const accessors = this.repeatingFormIndexedAccessors;
 
     const toDelete: number[] = [];
-    const toInsert: RepeatingFormIndexedAccessor<any, any, any>[] = [];
+    const toInsert: RepeatingFormIndexedAccessor<any, any>[] = [];
     accessors.forEach((accessor, i) => {
       if (i < index) {
         return;
@@ -185,7 +185,7 @@ export class RepeatingFormAccessor<
 
   private executeRenumber(
     toDelete: number[],
-    toInsert: RepeatingFormIndexedAccessor<any, any, any>[]
+    toInsert: RepeatingFormIndexedAccessor<any, any>[]
   ) {
     const accessors = this.repeatingFormIndexedAccessors;
 

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -8,9 +8,8 @@ import { FormAccessor } from "./form-accessor";
 import { ValidateOptions } from "./validate-options";
 
 export class RepeatingFormAccessor<
-  M,
-  D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  D extends FormDefinition<any>,
+  G extends GroupDefinition<any, D>
 > {
   name: string;
 
@@ -19,7 +18,7 @@ export class RepeatingFormAccessor<
 
   constructor(
     public state: FormState<any, any, any>,
-    public repeatingForm: RepeatingForm<M, D, G>,
+    public repeatingForm: RepeatingForm<any, D, G>,
     public parent: FormAccessor<any, any>,
     name: string
   ) {
@@ -80,7 +79,7 @@ export class RepeatingFormAccessor<
     result.initialize();
   }
 
-  index(index: number): RepeatingFormIndexedAccessor<M, D, G> {
+  index(index: number): RepeatingFormIndexedAccessor<any, D, G> {
     const accessor = this.repeatingFormIndexedAccessors.get(index);
     if (accessor == null) {
       throw new Error(`${index} is not a RepeatingFormIndexedAccessor`);
@@ -94,7 +93,7 @@ export class RepeatingFormAccessor<
   }
 
   @computed
-  get accessors(): RepeatingFormIndexedAccessor<M, D, G>[] {
+  get accessors(): RepeatingFormIndexedAccessor<any, D, G>[] {
     const result = [];
     for (let index = 0; index < this.length; index++) {
       result.push(this.index(index));

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -9,7 +9,7 @@ import { ValidateOptions } from "./validate-options";
 
 export class RepeatingFormAccessor<
   D extends FormDefinition<any>,
-  G extends GroupDefinition<any, D>
+  G extends GroupDefinition<D>
 > {
   name: string;
 

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -18,7 +18,7 @@ export class RepeatingFormAccessor<
 
   constructor(
     public state: FormState<any, any, any>,
-    public repeatingForm: RepeatingForm<any, D, G>,
+    public repeatingForm: RepeatingForm<D, G>,
     public parent: FormAccessor<any, any>,
     name: string
   ) {

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -20,7 +20,7 @@ export class RepeatingFormAccessor<
   constructor(
     public state: FormState<any, any, any>,
     public repeatingForm: RepeatingForm<M, D, G>,
-    public parent: FormAccessor<any, any, any>,
+    public parent: FormAccessor<any, any>,
     name: string
   ) {
     this.name = name;

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -6,9 +6,8 @@ import { FormAccessorBase } from "./form-accessor-base";
 import { FormAccessor } from "./form-accessor";
 
 export class RepeatingFormIndexedAccessor<
-  M,
-  D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  D extends FormDefinition<any>,
+  G extends GroupDefinition<any, D>
 > extends FormAccessorBase<D, G> {
   formAccessor: FormAccessor<D, G>;
 

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -7,7 +7,7 @@ import { FormAccessor } from "./form-accessor";
 
 export class RepeatingFormIndexedAccessor<
   D extends FormDefinition<any>,
-  G extends GroupDefinition<any, D>
+  G extends GroupDefinition<D>
 > extends FormAccessorBase<D, G> {
   formAccessor: FormAccessor<D, G>;
 

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -22,7 +22,7 @@ export class RepeatingFormIndexedAccessor<
     public state: FormState<any, any, any>,
     public definition: D,
     public groupDefinition: G | undefined,
-    public parent: RepeatingFormAccessor<M, D, G>,
+    public parent: RepeatingFormAccessor<D, G>,
     index: number
   ) {
     super();

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -1,5 +1,5 @@
 import { action, observable, computed } from "mobx";
-import { FormDefinition } from "./form";
+import { FormDefinition, GroupDefinition } from "./form";
 import { FormState } from "./state";
 import { RepeatingFormAccessor } from "./repeating-form-accessor";
 import { FormAccessorBase } from "./form-accessor-base";
@@ -7,9 +7,10 @@ import { FormAccessor } from "./form-accessor";
 
 export class RepeatingFormIndexedAccessor<
   M,
-  D extends FormDefinition<M>
-> extends FormAccessorBase<M, D> {
-  formAccessor: FormAccessor<M, D>;
+  D extends FormDefinition<M>,
+  G extends GroupDefinition<M, D>
+> extends FormAccessorBase<M, D, G> {
+  formAccessor: FormAccessor<M, D, G>;
 
   @observable
   index: number;
@@ -18,14 +19,21 @@ export class RepeatingFormIndexedAccessor<
   _addMode: boolean = false;
 
   constructor(
-    public state: FormState<any, any>,
+    public state: FormState<any, any, any>,
     public definition: D,
-    public parent: RepeatingFormAccessor<M, D>,
+    public groupDefinition: G | undefined,
+    public parent: RepeatingFormAccessor<M, D, G>,
     index: number
   ) {
     super();
     this.index = index;
-    this.formAccessor = new FormAccessor(state, definition, this, false);
+    this.formAccessor = new FormAccessor(
+      state,
+      definition,
+      groupDefinition,
+      this,
+      false
+    );
   }
 
   clear() {

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -9,8 +9,8 @@ export class RepeatingFormIndexedAccessor<
   M,
   D extends FormDefinition<M>,
   G extends GroupDefinition<M, D>
-> extends FormAccessorBase<M, D, G> {
-  formAccessor: FormAccessor<M, D, G>;
+> extends FormAccessorBase<D, G> {
+  formAccessor: FormAccessor<D, G>;
 
   @observable
   index: number;

--- a/src/state.ts
+++ b/src/state.ts
@@ -84,14 +84,14 @@ export class FormState<
   M,
   D extends FormDefinition<M>,
   G extends GroupDefinition<M, D>
-> extends FormAccessorBase<M, D, G> {
+> extends FormAccessorBase<D, G> {
   @observable
   additionalErrorTree: any;
 
   @observable
   saveStatus: SaveStatusOptions = "before";
 
-  formAccessor: FormAccessor<M, D, G>;
+  formAccessor: FormAccessor<D, G>;
   saveFunc: SaveFunc<M>;
   validationBeforeSave: ValidationOption;
   validationAfterSave: ValidationOption;

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,7 +35,7 @@ export interface ExtraValidation {
 }
 
 export interface RepeatingFormAccessorAllows {
-  (repeatingFormAccessor: RepeatingFormAccessor<any, any, any>): boolean;
+  (repeatingFormAccessor: RepeatingFormAccessor<any, any>): boolean;
 }
 
 export interface SaveFunc<M> {

--- a/src/state.ts
+++ b/src/state.ts
@@ -23,7 +23,7 @@ import { FormAccessorBase } from "./form-accessor-base";
 import { ValidateOptions } from "./validate-options";
 
 export interface FieldAccessorAllows {
-  (fieldAccessor: FieldAccessor<any, any, any>): boolean;
+  (fieldAccessor: FieldAccessor<any, any>): boolean;
 }
 
 export interface ErrorOrWarning {
@@ -31,7 +31,7 @@ export interface ErrorOrWarning {
 }
 
 export interface ExtraValidation {
-  (fieldAccessor: FieldAccessor<any, any, any>, value: any): ValidationResponse;
+  (fieldAccessor: FieldAccessor<any, any>, value: any): ValidationResponse;
 }
 
 export interface RepeatingFormAccessorAllows {
@@ -42,12 +42,12 @@ export interface SaveFunc<M> {
   (node: M): any;
 }
 
-export interface EventFunc<M, R, V> {
-  (event: any, accessor: FieldAccessor<M, R, V>): void;
+export interface EventFunc<R, V> {
+  (event: any, accessor: FieldAccessor<R, V>): void;
 }
 
-export interface UpdateFunc<M, R, V> {
-  (accessor: FieldAccessor<M, R, V>): void;
+export interface UpdateFunc<R, V> {
+  (accessor: FieldAccessor<R, V>): void;
 }
 
 // TODO: implement blur and pause validation
@@ -73,9 +73,9 @@ export interface FormStateOptions<M> {
   getWarning?: ErrorOrWarning;
 
   extraValidation?: ExtraValidation;
-  focus?: EventFunc<M, any, any>;
-  blur?: EventFunc<M, any, any>;
-  update?: UpdateFunc<M, any, any>;
+  focus?: EventFunc<any, any>;
+  blur?: EventFunc<any, any>;
+  update?: UpdateFunc<any, any>;
 }
 
 export type SaveStatusOptions = "before" | "rightAfter" | "after";
@@ -105,9 +105,9 @@ export class FormState<
   getWarningFunc: ErrorOrWarning;
   extraValidationFunc: ExtraValidation;
   private noRawUpdate: boolean;
-  focusFunc: EventFunc<M, any, any> | null;
-  blurFunc: EventFunc<M, any, any> | null;
-  updateFunc: UpdateFunc<M, any, any> | null;
+  focusFunc: EventFunc<any, any> | null;
+  blurFunc: EventFunc<any, any> | null;
+  updateFunc: UpdateFunc<any, any> | null;
 
   constructor(
     public form: Form<M, D, G>,

--- a/src/state.ts
+++ b/src/state.ts
@@ -83,7 +83,7 @@ export type SaveStatusOptions = "before" | "rightAfter" | "after";
 export class FormState<
   M,
   D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  G extends GroupDefinition<D>
 > extends FormAccessorBase<D, G> {
   @observable
   additionalErrorTree: any;

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,7 +1,12 @@
 import { action, computed, observable } from "mobx";
 import { IType, onPatch, resolvePath, applyPatch } from "mobx-state-tree";
 import { Accessor } from "./accessor";
-import { Form, FormDefinition, ValidationResponse } from "./form";
+import {
+  Form,
+  FormDefinition,
+  ValidationResponse,
+  GroupDefinition
+} from "./form";
 import {
   deepCopy,
   deleteByPath,
@@ -30,7 +35,7 @@ export interface ExtraValidation {
 }
 
 export interface RepeatingFormAccessorAllows {
-  (repeatingFormAccessor: RepeatingFormAccessor<any, any>): boolean;
+  (repeatingFormAccessor: RepeatingFormAccessor<any, any, any>): boolean;
 }
 
 export interface SaveFunc<M> {
@@ -75,17 +80,18 @@ export interface FormStateOptions<M> {
 
 export type SaveStatusOptions = "before" | "rightAfter" | "after";
 
-export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
+export class FormState<
   M,
-  D
-> {
+  D extends FormDefinition<M>,
+  G extends GroupDefinition<M, D>
+> extends FormAccessorBase<M, D, G> {
   @observable
   additionalErrorTree: any;
 
   @observable
   saveStatus: SaveStatusOptions = "before";
 
-  formAccessor: FormAccessor<M, D>;
+  formAccessor: FormAccessor<M, D, G>;
   saveFunc: SaveFunc<M>;
   validationBeforeSave: ValidationOption;
   validationAfterSave: ValidationOption;
@@ -104,7 +110,7 @@ export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
   updateFunc: UpdateFunc<M, any, any> | null;
 
   constructor(
-    public form: Form<M, D>,
+    public form: Form<M, D, G>,
     public node: M,
     options?: FormStateOptions<M>
   ) {
@@ -127,6 +133,7 @@ export class FormState<M, D extends FormDefinition<M>> extends FormAccessorBase<
     this.formAccessor = new FormAccessor(
       this,
       this.form.definition,
+      this.form.groupDefinition,
       null,
       addMode
     );

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -9,14 +9,14 @@ export class SubFormAccessor<
   M,
   D extends FormDefinition<M>,
   G extends GroupDefinition<M, D>
-> extends FormAccessorBase<M, D, G> {
-  formAccessor: FormAccessor<M, D, G>;
+> extends FormAccessorBase<D, G> {
+  formAccessor: FormAccessor<D, G>;
 
   constructor(
     public state: FormState<any, any, any>,
     public definition: D,
     public groupDefinition: G | undefined,
-    public parent: FormAccessor<any, any, any>,
+    public parent: FormAccessor<any, any>,
     public name: string
   ) {
     super();

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -1,5 +1,5 @@
 import { computed } from "mobx";
-import { FormDefinition } from "./form";
+import { FormDefinition, GroupDefinition } from "./form";
 import { FormState } from "./state";
 import { FormAccessor } from "./form-accessor";
 import { FormAccessorBase } from "./form-accessor-base";
@@ -7,19 +7,27 @@ import { ValidateOptions } from "./validate-options";
 
 export class SubFormAccessor<
   M,
-  D extends FormDefinition<M>
-> extends FormAccessorBase<M, D> {
-  formAccessor: FormAccessor<M, D>;
+  D extends FormDefinition<M>,
+  G extends GroupDefinition<M, D>
+> extends FormAccessorBase<M, D, G> {
+  formAccessor: FormAccessor<M, D, G>;
 
   constructor(
-    public state: FormState<any, any>,
+    public state: FormState<any, any, any>,
     public definition: D,
-    public parent: FormAccessor<any, any>,
+    public groupDefinition: G | undefined,
+    public parent: FormAccessor<any, any, any>,
     public name: string
   ) {
     super();
     this.name = name;
-    this.formAccessor = new FormAccessor(state, definition, this, false);
+    this.formAccessor = new FormAccessor(
+      state,
+      definition,
+      groupDefinition,
+      this,
+      false
+    );
   }
 
   clear() {

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -6,9 +6,8 @@ import { FormAccessorBase } from "./form-accessor-base";
 import { ValidateOptions } from "./validate-options";
 
 export class SubFormAccessor<
-  M,
-  D extends FormDefinition<M>,
-  G extends GroupDefinition<M, D>
+  D extends FormDefinition<any>,
+  G extends GroupDefinition<any, D>
 > extends FormAccessorBase<D, G> {
   formAccessor: FormAccessor<D, G>;
 

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -7,7 +7,7 @@ import { ValidateOptions } from "./validate-options";
 
 export class SubFormAccessor<
   D extends FormDefinition<any>,
-  G extends GroupDefinition<any, D>
+  G extends GroupDefinition<D>
 > extends FormAccessorBase<D, G> {
   formAccessor: FormAccessor<D, G>;
 

--- a/src/validation-props.ts
+++ b/src/validation-props.ts
@@ -1,7 +1,7 @@
 import { FieldAccessor } from "./field-accessor";
 
 export interface ValidationProps {
-  (accessor: FieldAccessor<any, any, any>): object;
+  (accessor: FieldAccessor<any, any>): object;
 }
 
 export let currentValidationProps: ValidationProps = () => {

--- a/test/groups.test.ts
+++ b/test/groups.test.ts
@@ -52,6 +52,53 @@ test("groups basic", async () => {
   expect(two.isValid).toBeTruthy();
 });
 
+test("groups exclude", async () => {
+  const M = types.model("M", {
+    a: types.number,
+    b: types.number,
+    c: types.number,
+    d: types.number
+  });
+
+  const form = new Form(
+    M,
+    {
+      a: new Field(converters.number),
+      b: new Field(converters.number),
+      c: new Field(converters.number),
+      d: new Field(converters.number)
+    },
+    {
+      one: new Group({ exclude: ["a", "b"] }),
+      two: new Group({ exclude: ["c", "d"] })
+    }
+  );
+
+  const o = M.create({ a: 1, b: 2, c: 3, d: 4 });
+
+  const state = form.state(o);
+  const a = state.field("a");
+  const b = state.field("b");
+  const c = state.field("c");
+  const d = state.field("d");
+  const one = state.group("one");
+  const two = state.group("two");
+
+  await a.setRaw("wrong");
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeFalsy();
+
+  await c.setRaw("wrong too");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeFalsy();
+
+  await a.setRaw("10");
+  await c.setRaw("30");
+
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeTruthy();
+});
+
 test("groups sub form", async () => {
   const N = types.model("N", {
     a: types.number,
@@ -120,6 +167,74 @@ test("groups sub form", async () => {
   expect(whole.isValid).toBeTruthy();
 });
 
+test("groups sub form exclude", async () => {
+  const N = types.model("N", {
+    a: types.number,
+    b: types.number,
+    c: types.number,
+    d: types.number
+  });
+
+  const M = types.model("M", {
+    field: types.number,
+    item: N
+  });
+
+  const form = new Form(
+    M,
+    {
+      field: new Field(converters.number),
+      item: new SubForm(
+        {
+          a: new Field(converters.number),
+          b: new Field(converters.number),
+          c: new Field(converters.number),
+          d: new Field(converters.number)
+        },
+        {
+          one: new Group({ exclude: ["a", "b"] }),
+          two: new Group({ exclude: ["c", "d"] })
+        }
+      )
+    },
+    { whole: new Group({ include: ["item"] }) }
+  );
+
+  const o = M.create({ field: 0, item: { a: 1, b: 2, c: 3, d: 4 } });
+
+  const state = form.state(o);
+  const field = state.field("field");
+  const item = state.subForm("item");
+  const whole = state.group("whole");
+  const a = item.field("a");
+  const b = item.field("b");
+  const c = item.field("c");
+  const d = item.field("d");
+  const one = item.group("one");
+  const two = item.group("two");
+
+  await a.setRaw("wrong");
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeFalsy();
+  expect(whole.isValid).toBeFalsy();
+
+  await c.setRaw("wrong too");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeFalsy();
+  expect(whole.isValid).toBeFalsy();
+
+  await a.setRaw("10");
+  await c.setRaw("30");
+
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeTruthy();
+  expect(whole.isValid).toBeTruthy();
+
+  await field.setRaw("wrong");
+  // whole is not affected as it only is affected by the sub form
+  expect(whole.isValid).toBeTruthy();
+});
+
 test("groups repeating form", async () => {
   const N = types.model("N", {
     a: types.number,
@@ -161,6 +276,59 @@ test("groups repeating form", async () => {
   await a.setRaw("wrong");
   expect(one.isValid).toBeFalsy();
   expect(two.isValid).toBeTruthy();
+
+  await c.setRaw("wrong too");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeFalsy();
+
+  await a.setRaw("10");
+  await c.setRaw("30");
+
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeTruthy();
+});
+
+test("groups repeating form exclude", async () => {
+  const N = types.model("N", {
+    a: types.number,
+    b: types.number,
+    c: types.number,
+    d: types.number
+  });
+
+  const M = types.model("M", {
+    items: types.array(N)
+  });
+
+  const form = new Form(M, {
+    items: new RepeatingForm(
+      {
+        a: new Field(converters.number),
+        b: new Field(converters.number),
+        c: new Field(converters.number),
+        d: new Field(converters.number)
+      },
+      {
+        one: new Group({ exclude: ["a", "b"] }),
+        two: new Group({ exclude: ["c", "d"] })
+      }
+    )
+  });
+
+  const o = M.create({ items: [{ a: 1, b: 2, c: 3, d: 4 }] });
+
+  const state = form.state(o);
+  const item0 = state.repeatingForm("items").index(0);
+  const a = item0.field("a");
+  const b = item0.field("b");
+  const c = item0.field("c");
+  const d = item0.field("d");
+  const one = item0.group("one");
+  const two = item0.group("two");
+
+  await a.setRaw("wrong");
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeFalsy();
 
   await c.setRaw("wrong too");
   expect(one.isValid).toBeFalsy();

--- a/test/groups.test.ts
+++ b/test/groups.test.ts
@@ -1,0 +1,174 @@
+import { configure } from "mobx";
+import { types } from "mobx-state-tree";
+import { Field, Form, Group, RepeatingForm, converters } from "../src";
+
+// "strict" leads to trouble during initialization.
+configure({ enforceActions: true });
+
+test("groups basic", async () => {
+  const M = types.model("M", {
+    a: types.number,
+    b: types.number,
+    c: types.number,
+    d: types.number
+  });
+
+  const form = new Form(
+    M,
+    {
+      a: new Field(converters.number),
+      b: new Field(converters.number),
+      c: new Field(converters.number),
+      d: new Field(converters.number)
+    },
+    {
+      one: new Group(["a", "b"]),
+      two: new Group(["c", "d"])
+    }
+  );
+
+  const o = M.create({ a: 1, b: 2, c: 3, d: 4 });
+
+  const state = form.state(o);
+  const a = state.field("a");
+  const b = state.field("b");
+  const c = state.field("c");
+  const d = state.field("d");
+  const one = state.group("one");
+  const two = state.group("two");
+
+  await a.setRaw("wrong");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeTruthy();
+
+  await c.setRaw("wrong too");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeFalsy();
+
+  await a.setRaw(10);
+  await c.setRaw(30);
+
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeTruthy();
+});
+
+// test("groups sub form", async () => {
+//   const N = types.model("N", {
+//     a: types.number,
+//     b: types.number,
+//     c: types.number,
+//     d: types.number
+//   });
+
+//   const M = types.model("M", {
+//     field: types.number,
+//     item: N
+//   });
+
+//   const form = new Form(
+//     M,
+//     {
+//       field: new Field(converters.number),
+//       item: new SubForm(
+//         {
+//           a: new Field(converters.number),
+//           b: new Field(converters.number),
+//           c: new Field(converters.number),
+//           d: new Field(converters.number)
+//         },
+//         {
+//           one: new Group(["a", "b"]),
+//           two: new Group(["c", "d"])
+//         }
+//       )
+//     },
+//     { whole: new Group(["item"]) }
+//   );
+
+//   const o = M.create({ field: 0, item: { a: 1, b: 2, c: 3, d: 4 } });
+
+//   const state = form.state(o);
+//   const field = state.field("field");
+//   const item = state.subForm("item");
+//   const whole = state.group("whole");
+//   const a = item.field("a");
+//   const b = item.field("b");
+//   const c = item.field("c");
+//   const d = item.field("d");
+//   const one = item.group("one");
+//   const two = item.group("two");
+
+//   await a.setRaw("wrong");
+//   expect(one.isValid).toBeFalsy();
+//   expect(two.isValid).toBeTruthy();
+//   expect(whole).toBeFalsy();
+
+//   await c.setRaw("wrong too");
+//   expect(one.isValid).toBeFalsy();
+//   expect(two.isValid).toBeFalsy();
+//   expect(whole).toBeFalsy();
+
+//   await a.setRaw(10);
+//   await c.setRaw(30);
+
+//   expect(one.isValid).toBeTruthy();
+//   expect(two.isValid).toBeTruthy();
+//   expect(whole).toBeTruthy();
+
+//   await field.setRaw("wrong");
+//   // whole is not affected as it only is affected by the sub form
+//   expect(whole).toBeTruthy();
+// });
+
+// test("groups repeating form", async () => {
+//   const N = types.model("N", {
+//     a: types.number,
+//     b: types.number,
+//     c: types.number,
+//     d: types.number
+//   });
+
+//   const M = types.model("M", {
+//     items: types.array(N)
+//   });
+
+//   const form = new Form(M, {
+//     items: new RepeatingForm(
+//       {
+//         a: new Field(converters.number),
+//         b: new Field(converters.number),
+//         c: new Field(converters.number),
+//         d: new Field(converters.number)
+//       },
+//       {
+//         one: new Group(["a", "b"]),
+//         two: new Group(["c", "d"])
+//       }
+//     )
+//   });
+
+//   const o = M.create({ items: [{ a: 1, b: 2, c: 3, d: 4 }] });
+
+//   const state = form.state(o);
+//   const item0 = state.repeatingForm("items").index(0);
+//   const a = item0.field("a");
+//   const b = item0.field("b");
+//   const c = item0.field("c");
+//   const d = item0.field("d");
+//   const one = item0.group("one");
+//   const two = item0.group("two");
+
+//   await a.setRaw("wrong");
+//   expect(one.isValid).toBeFalsy();
+//   expect(two.isValid).toBeTruthy();
+
+//   await c.setRaw("wrong too");
+//   expect(one.isValid).toBeFalsy();
+//   expect(two.isValid).toBeFalsy();
+
+//   await a.setRaw(10);
+//   await c.setRaw(30);
+
+//   expect(one.isValid).toBeTruthy();
+//   expect(two.isValid).toBeTruthy();
+// });

--- a/test/groups.test.ts
+++ b/test/groups.test.ts
@@ -1,6 +1,6 @@
 import { configure } from "mobx";
 import { types } from "mobx-state-tree";
-import { Field, Form, Group, RepeatingForm, converters } from "../src";
+import { Field, Form, Group, SubForm, RepeatingForm, converters } from "../src";
 
 // "strict" leads to trouble during initialization.
 configure({ enforceActions: true });
@@ -52,73 +52,73 @@ test("groups basic", async () => {
   expect(two.isValid).toBeTruthy();
 });
 
-// test("groups sub form", async () => {
-//   const N = types.model("N", {
-//     a: types.number,
-//     b: types.number,
-//     c: types.number,
-//     d: types.number
-//   });
+test("groups sub form", async () => {
+  const N = types.model("N", {
+    a: types.number,
+    b: types.number,
+    c: types.number,
+    d: types.number
+  });
 
-//   const M = types.model("M", {
-//     field: types.number,
-//     item: N
-//   });
+  const M = types.model("M", {
+    field: types.number,
+    item: N
+  });
 
-//   const form = new Form(
-//     M,
-//     {
-//       field: new Field(converters.number),
-//       item: new SubForm(
-//         {
-//           a: new Field(converters.number),
-//           b: new Field(converters.number),
-//           c: new Field(converters.number),
-//           d: new Field(converters.number)
-//         },
-//         {
-//           one: new Group(["a", "b"]),
-//           two: new Group(["c", "d"])
-//         }
-//       )
-//     },
-//     { whole: new Group(["item"]) }
-//   );
+  const form = new Form(
+    M,
+    {
+      field: new Field(converters.number),
+      item: new SubForm(
+        {
+          a: new Field(converters.number),
+          b: new Field(converters.number),
+          c: new Field(converters.number),
+          d: new Field(converters.number)
+        },
+        {
+          one: new Group({ include: ["a", "b"] }),
+          two: new Group({ include: ["c", "d"] })
+        }
+      )
+    },
+    { whole: new Group({ include: ["item"] }) }
+  );
 
-//   const o = M.create({ field: 0, item: { a: 1, b: 2, c: 3, d: 4 } });
+  const o = M.create({ field: 0, item: { a: 1, b: 2, c: 3, d: 4 } });
 
-//   const state = form.state(o);
-//   const field = state.field("field");
-//   const item = state.subForm("item");
-//   const whole = state.group("whole");
-//   const a = item.field("a");
-//   const b = item.field("b");
-//   const c = item.field("c");
-//   const d = item.field("d");
-//   const one = item.group("one");
-//   const two = item.group("two");
+  const state = form.state(o);
+  const field = state.field("field");
+  const item = state.subForm("item");
+  const whole = state.group("whole");
+  const a = item.field("a");
+  const b = item.field("b");
+  const c = item.field("c");
+  const d = item.field("d");
+  const one = item.group("one");
+  const two = item.group("two");
 
-//   await a.setRaw("wrong");
-//   expect(one.isValid).toBeFalsy();
-//   expect(two.isValid).toBeTruthy();
-//   expect(whole).toBeFalsy();
+  await a.setRaw("wrong");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeTruthy();
+  expect(whole.isValid).toBeFalsy();
 
-//   await c.setRaw("wrong too");
-//   expect(one.isValid).toBeFalsy();
-//   expect(two.isValid).toBeFalsy();
-//   expect(whole).toBeFalsy();
+  await c.setRaw("wrong too");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeFalsy();
+  expect(whole.isValid).toBeFalsy();
 
-//   await a.setRaw(10);
-//   await c.setRaw(30);
+  await a.setRaw("10");
+  await c.setRaw("30");
 
-//   expect(one.isValid).toBeTruthy();
-//   expect(two.isValid).toBeTruthy();
-//   expect(whole).toBeTruthy();
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeTruthy();
+  expect(whole.isValid).toBeTruthy();
 
-//   await field.setRaw("wrong");
-//   // whole is not affected as it only is affected by the sub form
-//   expect(whole).toBeTruthy();
-// });
+  await field.setRaw("wrong");
+  // whole is not affected as it only is affected by the sub form
+  expect(whole.isValid).toBeTruthy();
+});
 
 // test("groups repeating form", async () => {
 //   const N = types.model("N", {

--- a/test/groups.test.ts
+++ b/test/groups.test.ts
@@ -120,55 +120,55 @@ test("groups sub form", async () => {
   expect(whole.isValid).toBeTruthy();
 });
 
-// test("groups repeating form", async () => {
-//   const N = types.model("N", {
-//     a: types.number,
-//     b: types.number,
-//     c: types.number,
-//     d: types.number
-//   });
+test("groups repeating form", async () => {
+  const N = types.model("N", {
+    a: types.number,
+    b: types.number,
+    c: types.number,
+    d: types.number
+  });
 
-//   const M = types.model("M", {
-//     items: types.array(N)
-//   });
+  const M = types.model("M", {
+    items: types.array(N)
+  });
 
-//   const form = new Form(M, {
-//     items: new RepeatingForm(
-//       {
-//         a: new Field(converters.number),
-//         b: new Field(converters.number),
-//         c: new Field(converters.number),
-//         d: new Field(converters.number)
-//       },
-//       {
-//         one: new Group(["a", "b"]),
-//         two: new Group(["c", "d"])
-//       }
-//     )
-//   });
+  const form = new Form(M, {
+    items: new RepeatingForm(
+      {
+        a: new Field(converters.number),
+        b: new Field(converters.number),
+        c: new Field(converters.number),
+        d: new Field(converters.number)
+      },
+      {
+        one: new Group({ include: ["a", "b"] }),
+        two: new Group({ include: ["c", "d"] })
+      }
+    )
+  });
 
-//   const o = M.create({ items: [{ a: 1, b: 2, c: 3, d: 4 }] });
+  const o = M.create({ items: [{ a: 1, b: 2, c: 3, d: 4 }] });
 
-//   const state = form.state(o);
-//   const item0 = state.repeatingForm("items").index(0);
-//   const a = item0.field("a");
-//   const b = item0.field("b");
-//   const c = item0.field("c");
-//   const d = item0.field("d");
-//   const one = item0.group("one");
-//   const two = item0.group("two");
+  const state = form.state(o);
+  const item0 = state.repeatingForm("items").index(0);
+  const a = item0.field("a");
+  const b = item0.field("b");
+  const c = item0.field("c");
+  const d = item0.field("d");
+  const one = item0.group("one");
+  const two = item0.group("two");
 
-//   await a.setRaw("wrong");
-//   expect(one.isValid).toBeFalsy();
-//   expect(two.isValid).toBeTruthy();
+  await a.setRaw("wrong");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeTruthy();
 
-//   await c.setRaw("wrong too");
-//   expect(one.isValid).toBeFalsy();
-//   expect(two.isValid).toBeFalsy();
+  await c.setRaw("wrong too");
+  expect(one.isValid).toBeFalsy();
+  expect(two.isValid).toBeFalsy();
 
-//   await a.setRaw(10);
-//   await c.setRaw(30);
+  await a.setRaw("10");
+  await c.setRaw("30");
 
-//   expect(one.isValid).toBeTruthy();
-//   expect(two.isValid).toBeTruthy();
-// });
+  expect(one.isValid).toBeTruthy();
+  expect(two.isValid).toBeTruthy();
+});

--- a/test/groups.test.ts
+++ b/test/groups.test.ts
@@ -22,8 +22,8 @@ test("groups basic", async () => {
       d: new Field(converters.number)
     },
     {
-      one: new Group(["a", "b"]),
-      two: new Group(["c", "d"])
+      one: new Group({ include: ["a", "b"] }),
+      two: new Group({ include: ["c", "d"] })
     }
   );
 
@@ -45,8 +45,8 @@ test("groups basic", async () => {
   expect(one.isValid).toBeFalsy();
   expect(two.isValid).toBeFalsy();
 
-  await a.setRaw(10);
-  await c.setRaw(30);
+  await a.setRaw("10");
+  await c.setRaw("30");
 
   expect(one.isValid).toBeTruthy();
   expect(two.isValid).toBeTruthy();


### PR DESCRIPTION
I've reimplemented the group concept - documentation is included in the PR.

Implementing the groups I had to interact quite a bit with the generic types system and got a bit lost. I had an idea to simplify it and I did in this PR as well (which also simplified the group implementation a bit). But it's created a lot of churn in the type - lots of changes to angle brackets (<>). 

I think the frontend actually got better at checking types as a result (if you use .field() with a field that is defined in the model but not in the form, you'll now get an error in the typechecker, and previously you didn't).