### PR TITLE
When we save, the required message is visible even if we ignored it.

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -277,16 +277,30 @@ export class FormState<
   @action
   async save(options?: ValidateOptions): Promise<boolean> {
     const isValid = await this.validate(options);
+
+    // if we ignored required, we need to re-validate to restore
+    // the required messages (if any)
+    // XXX does this make sense to move this to validate itself?
+    if (options != null && options.ignoreRequired) {
+      // we don't care about the answer, only about updating the messages
+      // in the UI
+      await this.validate();
+    }
+
     this.setSaveStatus("rightAfter");
+
     if (!isValid) {
       return false;
     }
+
     const errors = await this.saveFunc(this.node);
+
     if (errors != null) {
       this.setErrors(errors);
       return false;
     }
     this.clearAdditionalErrors();
+
     return true;
   }
 

--- a/test/ignore.test.ts
+++ b/test/ignore.test.ts
@@ -58,12 +58,14 @@ test("FormState can be saved ignoring required", async () => {
 
   // now we save, ignoring required
   const saveResult = await state.save({ ignoreRequired: true });
-  expect(field.error).toBeUndefined();
+  // we still see the message, even though save succeeded
+  expect(field.error).toEqual("Required");
+  // but saving actually succeeded
   expect(o.foo).toEqual("");
   expect(saveResult).toBeTruthy();
   expect(saved).toBeTruthy();
 
-  // but saving again without ignoreRequired will be an error
+  // saving again without ignoreRequired will be an error
   const saveResult1 = await state.save();
   expect(saveResult1).toBeFalsy();
   expect(field.error).toEqual("Required");


### PR DESCRIPTION
We do this by simply revalidating if we happened to have ignored
required, so that the UI is updated again.