### PR TITLE
Context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,13 @@
 # 1.1.0
 
--   Added `context` to accessors. The validator functions get `context`
-    as a second argument. Converters get the context too with convert and
-    render.
+-   Added `context` to accessors. The validator functions get `context` as a
+    second argument. Converters get the context too with convert and render.
+    This allows you to implement convertors and validation functions with
+    application-dependent behavior; for instance depend on an i18n context.
+
+-   Extended behavior of `requiredError` and `conversionError`. You can now
+    configure them with a function too. This function receives a context
+    argument as well.
 
 # 1.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.1.0
+
+-   Added `context` to accessors. The validator functions get `context`
+    as a second argument. Converters get the context too with convert and
+    render.
+
 # 1.0.1
 
 -   Updated peerDependency for mobx-state-tree as well.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,35 @@ raw value is `null` and using this with basic data types (string, boolean,
 number and such) won't make the type checker happy as they don't accept "null".
 Use more specific converters instead.
 
+### Controlling the conversion error message
+
+A converter may fail to convert a raw value into a value if the raw value
+doesn't pass its `rawValidate` function or the converted value doesn't pass its
+`validate` function. In this case, the UI displays a conversion error. You can
+control this conversion error with the `conversionError` property for a field.
+
+```js
+const form = new Form(M, {
+    nr: new Field(converters.number, {
+        conversionError: "This conversion failed"
+    })
+});
+```
+
+You can also make `conversionError` a function. It takes a `context`
+as its first argument. Context is an arbitrary object you can pass into the `state` method from your application:
+
+```js
+const form = new Form(M, {
+    nr: new Field(converters.number, {
+        conversionError: context =>
+            context.language === "en"
+                ? "This conversion failed"
+                : "De conversie faalde"
+    })
+});
+```
+
 ### Defining a new converter
 
 You can define a new converter. For instance this is a converter which
@@ -383,7 +412,7 @@ an example.
 
 `convert`, `render`, `rawValidate` and `validate` all take a optional
 second argument, `context`. This is an arbitrary value you can pass
-as a `form.state()` option:
+in as a `form.state()` option from your application:
 
 ```js
 const formState = form.state(o, { context: { something: "FOO" } });
@@ -789,6 +818,21 @@ const form = new Form(M, {
     nr: new Field(converters.number, {
         required: true,
         requiredError: "This is required!"
+    })
+});
+```
+
+You can also set `requiredError` to a function, in which cases it receives a
+`context` argument (which you can pass in as an option to `state()`).
+
+```js
+const form = new Form(M, {
+    nr: new Field(converters.number, {
+        required: true,
+        requiredError: context =>
+            context.language === "en"
+                ? "This is required!"
+                : "Dit is verplicht!"
     })
 });
 ```

--- a/README.md
+++ b/README.md
@@ -345,6 +345,53 @@ raw value is `null` and using this with basic data types (string, boolean,
 number and such) won't make the type checker happy as they don't accept "null".
 Use more specific converters instead.
 
+### Defining a new converter
+
+You can define a new converter. For instance this is a converter which
+takes a text in the UI and considers `"t"` as `true` and the rest as
+`false`:
+
+```ts
+const boolean = new Converter<string, boolean>({
+    emptyRaw: "f",
+    convert(raw) {
+        return raw === "t";
+    },
+    render(value) {
+        return value ? "t" : "f";
+    }
+});
+```
+
+Converter is a generic type, with `<R, V>`. `R` is the type of the raw value
+(as you have to render in a React component), and `V` is the type of the
+converted value (as you have in the MST model).
+
+A converter needs to define a `convert` and a `render` method. `convert` takes
+a raw value and converts it to the MST value. `render` takes the MST value and
+converts it to the raw value. `rawValidate` is an optional function that checks
+whether the raw value is valid. `validate` is an optional function that checks
+whether the value is valid.
+
+`emptyRaw` is the raw value that should be shown if the field is empty in the
+UI.
+
+You can optionally set `defaultControlled`, the controlled props to be used by
+default for this converter. You can also optionally set `neverRequired`; this
+is handy for fields where the `required` status makes no sense -- a checkbox is
+an example.
+
+`convert`, `render`, `rawValidate` and `validate` all take a optional
+second argument, `context`. This is an arbitrary value you can pass
+as a `form.state()` option:
+
+```js
+const formState = form.state(o, { context: { something: "FOO" } });
+```
+
+This is useful when you want to make a converter that depends on
+an application-specific context.
+
 ## Controlled props
 
 A [controlled component](https://reactjs.org/docs/forms.html) is a React

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,10 +1,10 @@
 import { Controlled, controlled } from "./controlled";
 
 export interface ConverterOptions<R, V> {
-  convert(raw: R): V;
-  render(value: V): R;
-  rawValidate?(value: R): boolean | Promise<boolean>;
-  validate?(value: V): boolean | Promise<boolean>;
+  convert(raw: R, context?: any): V;
+  render(value: V, context?: any): R;
+  rawValidate?(value: R, context?: any): boolean | Promise<boolean>;
+  validate?(value: V, context?: any): boolean | Promise<boolean>;
   emptyRaw: R;
   defaultControlled?: Controlled;
   neverRequired?: boolean;
@@ -12,8 +12,8 @@ export interface ConverterOptions<R, V> {
 
 export interface IConverter<R, V> {
   emptyRaw: R;
-  convert(raw: R): Promise<ConversionResponse<V>>;
-  render(value: V): R;
+  convert(raw: R, context?: any): Promise<ConversionResponse<V>>;
+  render(value: V, context?: any): R;
   defaultControlled: Controlled;
   neverRequired: boolean;
   preprocessRaw(raw: R): R;
@@ -46,18 +46,24 @@ export class Converter<R, V> implements IConverter<R, V> {
     return raw;
   }
 
-  async convert(raw: R): Promise<ConversionResponse<V>> {
+  async convert(raw: R, context?: any): Promise<ConversionResponse<V>> {
     if (this.definition.rawValidate) {
-      const rawValidationSuccess = await this.definition.rawValidate(raw);
+      const rawValidationSuccess = await this.definition.rawValidate(
+        raw,
+        context
+      );
       if (!rawValidationSuccess) {
         return CONVERSION_ERROR;
       }
     }
 
-    const value = this.definition.convert(raw);
+    const value = this.definition.convert(raw, context);
 
     if (this.definition.validate) {
-      const rawValidationSuccess = await this.definition.validate(value);
+      const rawValidationSuccess = await this.definition.validate(
+        value,
+        context
+      );
       if (!rawValidationSuccess) {
         return CONVERSION_ERROR;
       }
@@ -65,7 +71,7 @@ export class Converter<R, V> implements IConverter<R, V> {
     return new ConversionValue<V>(value);
   }
 
-  render(value: V): R {
-    return this.definition.render(value);
+  render(value: V, context?: any): R {
+    return this.definition.render(value, context);
   }
 }

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -126,11 +126,11 @@ class Decimal implements IConverter<string, string> {
     return raw.trim();
   }
 
-  convert(raw: string) {
-    return this.converter.convert(raw);
+  convert(raw: string, context: any) {
+    return this.converter.convert(raw, context);
   }
-  render(value: string) {
-    return this.converter.render(value);
+  render(value: string, context: any) {
+    return this.converter.render(value, context);
   }
   getRaw(value: any) {
     return value;
@@ -198,18 +198,21 @@ class StringMaybe<V, RE, VE> implements IConverter<string, V | VE> {
     return raw.trim();
   }
 
-  async convert(raw: string): Promise<ConversionResponse<V | VE>> {
+  async convert(
+    raw: string,
+    context: any
+  ): Promise<ConversionResponse<V | VE>> {
     if (raw.trim() === "") {
       return new ConversionValue(this.emptyValue);
     }
-    return this.converter.convert(raw);
+    return this.converter.convert(raw, context);
   }
 
-  render(value: V | VE): string {
+  render(value: V | VE, context: any): string {
     if (value === this.emptyValue) {
       return "";
     }
-    return this.converter.render(value as V);
+    return this.converter.render(value as V, context);
   }
 }
 

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -82,7 +82,7 @@ export class FieldAccessor<R, V> {
         if (derivedValue === undefined) {
           return;
         }
-        this.setRaw(this.field.render(derivedValue));
+        this.setRaw(this.field.render(derivedValue, this.state.context));
       }
     );
     this._disposer = disposer;
@@ -125,7 +125,7 @@ export class FieldAccessor<R, V> {
     if (this.addMode) {
       return this.field.converter.emptyRaw;
     }
-    return this.field.render(this.value);
+    return this.field.render(this.value, this.state.context);
   }
 
   @computed
@@ -259,7 +259,12 @@ export class FieldAccessor<R, V> {
     try {
       // XXX is await correct here? we should await the result
       // later
-      processResult = await this.field.process(raw, this.required, options);
+      processResult = await this.field.process(
+        raw,
+        this.required,
+        this.state.context,
+        options
+      );
     } catch (e) {
       this.setError("Something went wrong");
       this.setValidating(false);
@@ -321,7 +326,7 @@ export class FieldAccessor<R, V> {
     // we don't use setRaw on the field as the value is already
     // correct. setting raw causes addMode for the field
     // to be disabled
-    this._raw = this.field.render(value);
+    this._raw = this.field.render(value, this.state.context);
     // trigger validation
     this.validate();
   }

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -54,6 +54,11 @@ export class FieldAccessor<R, V> {
     return this.parent.path + "/" + this.name;
   }
 
+  @computed
+  get context(): any {
+    return this.state.context;
+  }
+
   @action
   setDisposer(disposer: IReactionDisposer) {
     this._disposer = disposer;

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -26,6 +26,11 @@ export abstract class FormAccessorBase<
   }
 
   @computed
+  get context(): any {
+    return this.formAccessor.context;
+  }
+
+  @computed
   get warningValue(): string | undefined {
     return this.warning;
   }

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -78,6 +78,11 @@ export class FormAccessor<
   }
 
   @computed
+  get context(): any {
+    return this.state.context;
+  }
+
+  @computed
   get isValid(): boolean {
     return this.accessors.every(accessor => accessor.isValid);
   }

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -34,6 +34,11 @@ export class RepeatingFormAccessor<
     return this.parent.path + "/" + this.name;
   }
 
+  @computed
+  get context(): any {
+    return this.state.context;
+  }
+
   async validate(options?: ValidateOptions): Promise<boolean> {
     const promises: Promise<any>[] = [];
     for (const accessor of this.accessors) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -9,7 +9,6 @@ import {
 import { Accessor } from "./accessor";
 import {
   Form,
-  FormDefinition,
   FormDefinitionForModel,
   ValidationResponse,
   GroupDefinition
@@ -18,7 +17,6 @@ import {
   deepCopy,
   deleteByPath,
   getByPath,
-  isInt,
   pathToSteps,
   stepsToPath
 } from "./utils";
@@ -83,6 +81,8 @@ export interface FormStateOptions<M> {
   focus?: EventFunc<any, any>;
   blur?: EventFunc<any, any>;
   update?: UpdateFunc<any, any>;
+
+  context?: any;
 }
 
 export type SaveStatusOptions = "before" | "rightAfter" | "after";
@@ -115,6 +115,8 @@ export class FormState<
   focusFunc: EventFunc<any, any> | null;
   blurFunc: EventFunc<any, any> | null;
   updateFunc: UpdateFunc<any, any> | null;
+
+  _context: any;
 
   constructor(
     public form: Form<M, D, G>,
@@ -163,6 +165,7 @@ export class FormState<
       this.focusFunc = null;
       this.blurFunc = null;
       this.updateFunc = null;
+      this._context = undefined;
     } else {
       this.saveFunc = options.save ? options.save : defaultSaveFunc;
       this.isDisabledFunc = options.isDisabled
@@ -192,7 +195,13 @@ export class FormState<
       this.focusFunc = options.focus ? options.focus : null;
       this.blurFunc = options.blur ? options.blur : null;
       this.updateFunc = options.update ? options.update : null;
+      this._context = options.context;
     }
+  }
+
+  @computed
+  get context(): any {
+    return this._context;
   }
 
   @action

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,6 +1,13 @@
 import { configure } from "mobx";
 import { types } from "mobx-state-tree";
-import { Field, Form, SubForm, RepeatingForm, converters } from "../src";
+import {
+  Field,
+  Form,
+  SubForm,
+  RepeatingForm,
+  converters,
+  Converter
+} from "../src";
 
 // "always" leads to trouble during initialization.
 configure({ enforceActions: "observed" });
@@ -81,4 +88,136 @@ test("context passed to repeating form indexed accessor", async () => {
   const f = repeatingForm.index(0);
 
   expect(f.context).toEqual("foo");
+});
+
+test("context in validate", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string, {
+      validators: [(value, context) => value !== context.theValue && "Wrong"]
+    })
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const state = form.state(o, { context: { theValue: "correct" } });
+  const field = state.field("foo");
+
+  expect(field.raw).toEqual("FOO");
+  await field.setRaw("BAR");
+  expect(field.raw).toEqual("BAR");
+  expect(field.error).toEqual("Wrong");
+  expect(field.value).toEqual("FOO");
+  await field.setRaw("correct");
+  expect(field.error).toBeUndefined();
+  expect(field.value).toEqual("correct");
+
+  const o2 = M.create({ foo: "FOO" });
+  const state2 = form.state(o, { context: { theValue: "other" } });
+
+  const field2 = state2.field("foo");
+
+  await field2.setRaw("correct");
+  expect(field2.error).toEqual("Wrong");
+});
+
+test("context in converter", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const myConverter = new Converter<string, string>({
+    emptyRaw: "",
+    rawValidate(raw, context) {
+      return raw.startsWith(context.prefix);
+    },
+    convert(raw) {
+      return raw;
+    },
+    render(value) {
+      return value;
+    }
+  });
+
+  const form = new Form(M, {
+    foo: new Field(myConverter)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const state = form.state(o, { context: { prefix: "X" } });
+  const field = state.field("foo");
+
+  await field.setRaw("XBAR");
+  expect(field.raw).toEqual("XBAR");
+  expect(field.error).toBeUndefined();
+
+  await field.setRaw("YBAR");
+  expect(field.value).toEqual("XBAR");
+  expect(field.error).toEqual("Could not convert");
+});
+
+test("context in converter in convert", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const myConverter = new Converter<string, string>({
+    emptyRaw: "",
+    convert(raw: string, context: any) {
+      return context.prefix + raw;
+    },
+    render(value) {
+      return value;
+    }
+  });
+
+  const form = new Form(M, {
+    foo: new Field(myConverter)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const state = form.state(o, { context: { prefix: "X" } });
+  const field = state.field("foo");
+
+  await field.setRaw("BAR");
+  expect(field.error).toBeUndefined();
+  expect(field.raw).toEqual("BAR");
+  expect(field.value).toEqual("XBAR");
+});
+
+test("context in converter in render", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const myConverter = new Converter<string, string>({
+    emptyRaw: "",
+    convert(raw: string) {
+      return raw;
+    },
+    render(value, context) {
+      return context.prefix + value;
+    }
+  });
+
+  const form = new Form(M, {
+    foo: new Field(myConverter)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const state = form.state(o, { context: { prefix: "X" } });
+  const field = state.field("foo");
+
+  expect(field.raw).toEqual("XFOO");
+
+  await field.setRaw("BAR");
+  expect(field.error).toBeUndefined();
+  expect(field.raw).toEqual("BAR");
+  expect(field.value).toEqual("BAR");
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,0 +1,84 @@
+import { configure } from "mobx";
+import { types } from "mobx-state-tree";
+import { Field, Form, SubForm, RepeatingForm, converters } from "../src";
+
+// "always" leads to trouble during initialization.
+configure({ enforceActions: "observed" });
+
+test("context passed to field accessor", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const state = form.state(o, { context: "foo" });
+  const field = state.field("foo");
+
+  expect(field.context).toEqual("foo");
+});
+
+test("context passed to sub form accessor", async () => {
+  const N = types.model("N", {
+    bar: types.string
+  });
+  const M = types.model("M", {
+    foo: N
+  });
+
+  const form = new Form(M, {
+    foo: new SubForm({ bar: new Field(converters.string) })
+  });
+
+  const o = M.create({ foo: { bar: "BAR" } });
+
+  const state = form.state(o, { context: "foo" });
+  const subForm = state.subForm("foo");
+
+  expect(subForm.context).toEqual("foo");
+});
+
+test("context passed to repeating form accessor", async () => {
+  const N = types.model("N", {
+    bar: types.string
+  });
+  const M = types.model("M", {
+    foo: types.array(N)
+  });
+
+  const form = new Form(M, {
+    foo: new RepeatingForm({ bar: new Field(converters.string) })
+  });
+
+  const o = M.create({ foo: [{ bar: "BAR" }] });
+
+  const state = form.state(o, { context: "foo" });
+  const repeatingForm = state.repeatingForm("foo");
+
+  expect(repeatingForm.context).toEqual("foo");
+});
+
+test("context passed to repeating form indexed accessor", async () => {
+  const N = types.model("N", {
+    bar: types.string
+  });
+  const M = types.model("M", {
+    foo: types.array(N)
+  });
+
+  const form = new Form(M, {
+    foo: new RepeatingForm({ bar: new Field(converters.string) })
+  });
+
+  const o = M.create({ foo: [{ bar: "BAR" }] });
+
+  const state = form.state(o, { context: "foo" });
+  const repeatingForm = state.repeatingForm("foo");
+  const f = repeatingForm.index(0);
+
+  expect(f.context).toEqual("foo");
+});


### PR DESCRIPTION
Introduce a context mechanism. This can be used to pass in an internationalization context or other information to control the behavior of converters, validation functions, and error messages.