### PR TITLE
State converter options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+# 1.2.0
+
+-   Added `converterOptions` to converters. `converterOptions` consists of three
+    options: `decimalSeparator` allows you to specify the character used to separate
+    the integer part of a number from the fractional part. `thousandSeparator`
+    allows you to specify the character used to group the thousands together.
+    `renderThousands` determines whether or not the thousand separators are
+    rendered.
+
 # 1.1.0
 
 -   Added `context` to accessors. The validator functions get `context` as a

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -6,3 +6,4 @@ Contributors:
 -   Gerjon Mensinga
 -   Subhi Dweik
 -   Koen de Leijer
+-   Randy Wanga

--- a/README.md
+++ b/README.md
@@ -433,9 +433,10 @@ default for this converter. You can also optionally set `neverRequired`; this
 is handy for fields where the `required` status makes no sense -- a checkbox is
 an example.
 
-`convert`, `render`, `rawValidate` and `validate` all take a optional
-second argument, `context`. This is an arbitrary value you can pass
-in as a `form.state()` option from your application:
+`convert`, `render`, `rawValidate` and `validate` all take an optional
+second argument, `options`. With `options`, you can pass `converterOptions` and
+a `context`. `context` is an arbitrary value you can pass in as a `form.state()`
+option from your application:
 
 ```js
 const formState = form.state(o, { context: { something: "FOO" } });

--- a/README.md
+++ b/README.md
@@ -301,6 +301,13 @@ other object:
     `decimalPlaces` (default 2) after the period. With `allowNegative`
     (boolean, default true) you can specify if negatives are allowed
 
+Number and decimal converters also respond to a handful of options through the
+use of `converterOptions`. `decimalSeparator` specifies the character used to
+separate the integral and fractional part of a number or decimal.
+`thousandSeparator` specifies the character used to group thousands together.
+`renderThousands` determines whether or not the thousand separators should be
+rendered.
+
 ### Boolean
 
 `converters.boolean`: raw value is a boolean, value is also a boolean. The
@@ -344,6 +351,22 @@ including `null`. Prefer `converters.model` if you can. Warning: the default
 raw value is `null` and using this with basic data types (string, boolean,
 number and such) won't make the type checker happy as they don't accept "null".
 Use more specific converters instead.
+
+### Converter options
+
+Converters can be passed various options. Number and decimal converters respond
+to `decimalSeparator`, `thousandSeparator` and `renderThousands`. These can be
+set in a `converterOptions` argument on the state:
+
+```js
+const formState = form.state(o, {
+    converterOptions: {
+        decimalSeparator: ".",
+        thousandSeparator: ",",
+        renderThousands: false
+    }
+});
+```
 
 ### Controlling the conversion error message
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -35,7 +35,7 @@ export interface IConverter<R, V> {
   render(value: V, options: StateConverterOptionsWithContext): R;
   defaultControlled: Controlled;
   neverRequired: boolean;
-  preprocessRaw(raw: R): R;
+  preprocessRaw(raw: R, options: StateConverterOptionsWithContext): R;
 }
 
 export class ConversionValue<V> {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -3,6 +3,7 @@ import { Controlled, controlled } from "./controlled";
 export interface StateConverterOptions {
   decimalSeparator?: string;
   thousandSeparator?: string;
+  renderThousands?: boolean;
 }
 
 export interface StateConverterOptionsWithContext

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,10 +1,26 @@
 import { Controlled, controlled } from "./controlled";
 
+export interface StateConverterOptions {
+  decimalSeparator?: string;
+  thousandSeparator?: string;
+}
+
+export interface StateConverterOptionsWithContext
+  extends StateConverterOptions {
+  context?: any;
+}
+
 export interface ConverterOptions<R, V> {
-  convert(raw: R, context?: any): V;
-  render(value: V, context?: any): R;
-  rawValidate?(value: R, context?: any): boolean | Promise<boolean>;
-  validate?(value: V, context?: any): boolean | Promise<boolean>;
+  convert(raw: R, options: StateConverterOptionsWithContext): V;
+  render(value: V, options: StateConverterOptionsWithContext): R;
+  rawValidate?(
+    value: R,
+    options: StateConverterOptionsWithContext
+  ): boolean | Promise<boolean>;
+  validate?(
+    value: V,
+    options: StateConverterOptionsWithContext
+  ): boolean | Promise<boolean>;
   emptyRaw: R;
   defaultControlled?: Controlled;
   neverRequired?: boolean;
@@ -12,8 +28,11 @@ export interface ConverterOptions<R, V> {
 
 export interface IConverter<R, V> {
   emptyRaw: R;
-  convert(raw: R, context?: any): Promise<ConversionResponse<V>>;
-  render(value: V, context?: any): R;
+  convert(
+    raw: R,
+    options: StateConverterOptionsWithContext
+  ): Promise<ConversionResponse<V>>;
+  render(value: V, options: StateConverterOptionsWithContext): R;
   defaultControlled: Controlled;
   neverRequired: boolean;
   preprocessRaw(raw: R): R;
@@ -46,23 +65,26 @@ export class Converter<R, V> implements IConverter<R, V> {
     return raw;
   }
 
-  async convert(raw: R, context?: any): Promise<ConversionResponse<V>> {
+  async convert(
+    raw: R,
+    options: StateConverterOptionsWithContext
+  ): Promise<ConversionResponse<V>> {
     if (this.definition.rawValidate) {
       const rawValidationSuccess = await this.definition.rawValidate(
         raw,
-        context
+        options
       );
       if (!rawValidationSuccess) {
         return CONVERSION_ERROR;
       }
     }
 
-    const value = this.definition.convert(raw, context);
+    const value = this.definition.convert(raw, options);
 
     if (this.definition.validate) {
       const rawValidationSuccess = await this.definition.validate(
         value,
-        context
+        options
       );
       if (!rawValidationSuccess) {
         return CONVERSION_ERROR;
@@ -71,7 +93,7 @@ export class Converter<R, V> implements IConverter<R, V> {
     return new ConversionValue<V>(value);
   }
 
-  render(value: V, context?: any): R {
-    return this.definition.render(value, context);
+  render(value: V, options: StateConverterOptionsWithContext): R {
+    return this.definition.render(value, options);
   }
 }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -61,7 +61,7 @@ export class Converter<R, V> implements IConverter<R, V> {
     this.neverRequired = !!definition.neverRequired;
   }
 
-  preprocessRaw(raw: R): R {
+  preprocessRaw(raw: R, options?: StateConverterOptionsWithContext): R {
     return raw;
   }
 

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -75,7 +75,7 @@ function renderThousandSeparators(
   value: string,
   options: StateConverterOptionsWithContext
 ) {
-  if (options.thousandSeparator == null) {
+  if (options.thousandSeparator == null || !options.renderThousands) {
     return value;
   }
   return value.replace(/\B(?=(\d{3})+(?!\d))/g, options.thousandSeparator);

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -14,42 +14,35 @@ import { identity } from "./utils";
 const NUMBER_REGEX = new RegExp("^-?(0|[1-9]\\d*)(\\.\\d*)?$");
 const INTEGER_REGEX = new RegExp("^-?(0|[1-9]\\d*)$");
 
-function processSeparators(
-  raw: string,
-  options: StateConverterOptionsWithContext
-) {
-  return removeThousandSeparators(
-    replaceDecimalSeparator(raw, options),
-    options
-  );
-}
-
 function replaceDecimalSeparator(
   raw: string,
   options: StateConverterOptionsWithContext
 ) {
-  if (options.decimalSeparator != null) {
-    raw = raw.replace(options.decimalSeparator, ".");
+  if (options.decimalSeparator == null) {
+    return raw;
+  } else {
+    return raw.replace(options.decimalSeparator, ".");
   }
-  return raw;
 }
 
 function replaceWithDecimalSeparator(
   value: string,
   options: StateConverterOptionsWithContext
 ) {
-  if (options.decimalSeparator != null) {
-    value.split(".").join(options.decimalSeparator);
+  if (options.decimalSeparator == null) {
+    return value;
+  } else {
+    return value.split(".").join(options.decimalSeparator);
   }
-  return value;
 }
 
 function removeThousandSeparators(
   raw: string,
   options: StateConverterOptionsWithContext
 ) {
-  //remove thousand separators
-  if (options.thousandSeparator != null) {
+  if (options.thousandSeparator == null) {
+    return raw;
+  } else {
     const splitRaw = raw.split(options.thousandSeparator);
     //value before the first thousand separator has to be of length 1, 2 or 3
     if (splitRaw[0].length < 1 || splitRaw[0].length > 3) {
@@ -62,21 +55,29 @@ function removeThousandSeparators(
       }
     }
     //turn split string back into full string without thousand separators
-    raw = splitRaw.join("");
+    return splitRaw.join("");
   }
-  return raw;
 }
 
 function addThousandSeparators(
   value: string,
   options: StateConverterOptionsWithContext
 ) {
-  if (options.thousandSeparator != null) {
-    //add thousand separators
-    return value.replace(/\B(?=(\d{3})+(?!\d))/g, options.thousandSeparator);
-  } else {
+  if (options.thousandSeparator == null) {
     return value;
+  } else {
+    return value.replace(/\B(?=(\d{3})+(?!\d))/g, options.thousandSeparator);
   }
+}
+
+function processSeparators(
+  raw: string,
+  options: StateConverterOptionsWithContext
+) {
+  return removeThousandSeparators(
+    replaceDecimalSeparator(raw, options),
+    options
+  );
 }
 
 export class StringConverter<V> extends Converter<string, V> {
@@ -113,13 +114,13 @@ const number = new StringConverter<number>({
     return +raw;
   },
   render(value, options) {
-    if (options != null) {
+    if (options == null) {
+      return value.toString();
+    } else {
       return addThousandSeparators(
         replaceWithDecimalSeparator(value.toString(), options),
         options
       );
-    } else {
-      return value.toString();
     }
   }
 });

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -39,6 +39,16 @@ function processSeparators(
   return raw;
 }
 
+function replaceDecimalSeparator(
+  value: string,
+  options: StateConverterOptionsWithContext
+) {
+  if (options.decimalSeparator != null) {
+    value.split(".").join(options.decimalSeparator);
+  }
+  return value;
+}
+
 function addThousandSeparators(
   value: string,
   options: StateConverterOptionsWithContext
@@ -86,7 +96,10 @@ const number = new StringConverter<number>({
   },
   render(value, options) {
     if (options != null) {
-      return addThousandSeparators(value.toString(), options);
+      return addThousandSeparators(
+        replaceDecimalSeparator(value.toString(), options),
+        options
+      );
     } else {
       return value.toString();
     }
@@ -163,7 +176,10 @@ class Decimal implements IConverter<string, string> {
         return raw;
       },
       render(value, options) {
-        return addThousandSeparators(value, options);
+        return addThousandSeparators(
+          replaceDecimalSeparator(value.toString(), options),
+          options
+        );
       }
     });
   }

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -5,7 +5,8 @@ import {
   ConversionResponse,
   ConversionValue,
   Converter,
-  IConverter
+  IConverter,
+  StateConverterOptionsWithContext
 } from "./converter";
 import { Controlled, controlled } from "./controlled";
 import { identity } from "./utils";
@@ -126,11 +127,11 @@ class Decimal implements IConverter<string, string> {
     return raw.trim();
   }
 
-  convert(raw: string, context: any) {
-    return this.converter.convert(raw, context);
+  convert(raw: string, options: StateConverterOptionsWithContext) {
+    return this.converter.convert(raw, options);
   }
-  render(value: string, context: any) {
-    return this.converter.render(value, context);
+  render(value: string, options: StateConverterOptionsWithContext) {
+    return this.converter.render(value, options);
   }
   getRaw(value: any) {
     return value;
@@ -200,19 +201,19 @@ class StringMaybe<V, RE, VE> implements IConverter<string, V | VE> {
 
   async convert(
     raw: string,
-    context: any
+    options: StateConverterOptionsWithContext
   ): Promise<ConversionResponse<V | VE>> {
     if (raw.trim() === "") {
       return new ConversionValue(this.emptyValue);
     }
-    return this.converter.convert(raw, context);
+    return this.converter.convert(raw, options);
   }
 
-  render(value: V | VE, context: any): string {
+  render(value: V | VE, options: StateConverterOptionsWithContext): string {
     if (value === this.emptyValue) {
       return "";
     }
-    return this.converter.render(value as V, context);
+    return this.converter.render(value as V, options);
   }
 }
 

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -34,6 +34,7 @@ function processSeparators(
         return raw;
       }
     }
+    //turn split string back into full string without thousand separators
     raw = splitRaw.join("");
   }
   return raw;

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -117,14 +117,45 @@ class Decimal implements IConverter<string, string> {
       convert(raw) {
         return raw;
       },
-      render(value) {
-        return value;
+      render(value, options) {
+        if (options.thousandSeparator != null) {
+          //add thousand separators
+          return value.replace(
+            /\B(?=(\d{3})+(?!\d))/g,
+            options.thousandSeparator
+          );
+        } else {
+          return value;
+        }
       }
     });
   }
 
-  preprocessRaw(raw: string): string {
-    return raw.trim();
+  preprocessRaw(
+    raw: string,
+    options: StateConverterOptionsWithContext
+  ): string {
+    raw = raw.trim();
+    //replace decimal separator with .
+    if (options.decimalSeparator != null) {
+      raw = raw.replace(options.decimalSeparator, ".");
+    }
+    //remove thousand separators
+    if (options.thousandSeparator != null) {
+      const splitRaw = raw.split(options.thousandSeparator);
+      //value before the first thousand separator has to be of length 1, 2 or 3
+      if (splitRaw[0].length < 1 || splitRaw[0].length > 3) {
+        return raw;
+      }
+      //all other separated values should have length 3
+      for (let i = 1; i < splitRaw.length; i++) {
+        if (splitRaw[i].length !== 3) {
+          return raw;
+        }
+      }
+      raw = splitRaw.join("");
+    }
+    return raw;
   }
 
   convert(raw: string, options: StateConverterOptionsWithContext) {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -18,9 +18,36 @@ function processSeparators(
   raw: string,
   options: StateConverterOptionsWithContext
 ) {
+  return removeThousandSeparators(
+    replaceDecimalSeparator(raw, options),
+    options
+  );
+}
+
+function replaceDecimalSeparator(
+  raw: string,
+  options: StateConverterOptionsWithContext
+) {
   if (options.decimalSeparator != null) {
     raw = raw.replace(options.decimalSeparator, ".");
   }
+  return raw;
+}
+
+function replaceWithDecimalSeparator(
+  value: string,
+  options: StateConverterOptionsWithContext
+) {
+  if (options.decimalSeparator != null) {
+    value.split(".").join(options.decimalSeparator);
+  }
+  return value;
+}
+
+function removeThousandSeparators(
+  raw: string,
+  options: StateConverterOptionsWithContext
+) {
   //remove thousand separators
   if (options.thousandSeparator != null) {
     const splitRaw = raw.split(options.thousandSeparator);
@@ -38,16 +65,6 @@ function processSeparators(
     raw = splitRaw.join("");
   }
   return raw;
-}
-
-function replaceDecimalSeparator(
-  value: string,
-  options: StateConverterOptionsWithContext
-) {
-  if (options.decimalSeparator != null) {
-    value.split(".").join(options.decimalSeparator);
-  }
-  return value;
 }
 
 function addThousandSeparators(
@@ -98,7 +115,7 @@ const number = new StringConverter<number>({
   render(value, options) {
     if (options != null) {
       return addThousandSeparators(
-        replaceDecimalSeparator(value.toString(), options),
+        replaceWithDecimalSeparator(value.toString(), options),
         options
       );
     } else {
@@ -178,7 +195,7 @@ class Decimal implements IConverter<string, string> {
       },
       render(value, options) {
         return addThousandSeparators(
-          replaceDecimalSeparator(value.toString(), options),
+          replaceWithDecimalSeparator(value.toString(), options),
           options
         );
       }

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -125,7 +125,10 @@ export class FieldAccessor<R, V> {
     if (this.addMode) {
       return this.field.converter.emptyRaw;
     }
-    return this.field.render(this.value, this.state.context);
+    return this.field.render(
+      this.value,
+      this.state.stateConverterOptionsWithContext
+    );
   }
 
   @computed
@@ -262,7 +265,7 @@ export class FieldAccessor<R, V> {
       processResult = await this.field.process(
         raw,
         this.required,
-        this.state.context,
+        this.state.stateConverterOptionsWithContext,
         options
       );
     } catch (e) {

--- a/src/form.ts
+++ b/src/form.ts
@@ -226,7 +226,7 @@ export class Field<R, V> {
     stateConverterOptions: StateConverterOptionsWithContext,
     options?: ProcessOptions
   ): Promise<ProcessResponse<V>> {
-    raw = this.converter.preprocessRaw(raw);
+    raw = this.converter.preprocessRaw(raw, stateConverterOptions);
     const ignoreRequired = options != null ? options.ignoreRequired : false;
     if (
       !this.converter.neverRequired &&

--- a/src/state.ts
+++ b/src/state.ts
@@ -122,6 +122,7 @@ export class FormState<
   updateFunc: UpdateFunc<any, any> | null;
 
   _context: any;
+  _converterOptions: StateConverterOptions;
 
   constructor(
     public form: Form<M, D, G>,
@@ -171,6 +172,7 @@ export class FormState<
       this.blurFunc = null;
       this.updateFunc = null;
       this._context = undefined;
+      this._converterOptions = {};
     } else {
       this.saveFunc = options.save ? options.save : defaultSaveFunc;
       this.isDisabledFunc = options.isDisabled
@@ -201,6 +203,7 @@ export class FormState<
       this.blurFunc = options.blur ? options.blur : null;
       this.updateFunc = options.update ? options.update : null;
       this._context = options.context;
+      this._converterOptions = options.converterOptions || {};
     }
   }
 
@@ -211,7 +214,7 @@ export class FormState<
 
   @computed
   get stateConverterOptionsWithContext(): StateConverterOptionsWithContext {
-    return { context: this.context };
+    return { context: this.context, ...this._converterOptions };
   }
 
   @action

--- a/src/state.ts
+++ b/src/state.ts
@@ -26,6 +26,10 @@ import { RepeatingFormAccessor } from "./repeating-form-accessor";
 import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor";
 import { FormAccessorBase } from "./form-accessor-base";
 import { ValidateOptions } from "./validate-options";
+import {
+  StateConverterOptions,
+  StateConverterOptionsWithContext
+} from "./converter";
 
 export interface FieldAccessorAllows {
   (fieldAccessor: FieldAccessor<any, any>): boolean;
@@ -83,6 +87,7 @@ export interface FormStateOptions<M> {
   update?: UpdateFunc<any, any>;
 
   context?: any;
+  converterOptions?: StateConverterOptions;
 }
 
 export type SaveStatusOptions = "before" | "rightAfter" | "after";
@@ -202,6 +207,11 @@ export class FormState<
   @computed
   get context(): any {
     return this._context;
+  }
+
+  @computed
+  get stateConverterOptionsWithContext(): StateConverterOptionsWithContext {
+    return { context: this.context };
   }
 
   @action

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -8,6 +8,7 @@ import {
   converters,
   Converter
 } from "../src";
+import { type } from "os";
 
 // "always" leads to trouble during initialization.
 configure({ enforceActions: "observed" });
@@ -131,8 +132,8 @@ test("context in converter", async () => {
 
   const myConverter = new Converter<string, string>({
     emptyRaw: "",
-    rawValidate(raw, context) {
-      return raw.startsWith(context.prefix);
+    rawValidate(raw, options) {
+      return raw.startsWith(options.context.prefix);
     },
     convert(raw) {
       return raw;
@@ -167,8 +168,8 @@ test("context in converter in convert", async () => {
 
   const myConverter = new Converter<string, string>({
     emptyRaw: "",
-    convert(raw: string, context: any) {
-      return context.prefix + raw;
+    convert(raw: string, options) {
+      return options.context.prefix + raw;
     },
     render(value) {
       return value;
@@ -200,8 +201,8 @@ test("context in converter in render", async () => {
     convert(raw: string) {
       return raw;
     },
-    render(value, context) {
-      return context.prefix + value;
+    render(value, options) {
+      return options.context.prefix + value;
     }
   });
 
@@ -297,4 +298,26 @@ test("conversionError dynamic with context", async () => {
   await field.setRaw("not a number");
   expect(field.value).toEqual(4);
   expect(field.error).toEqual("Not a number!!");
+});
+
+test("converter options in converter in convert", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.decimal())
+  });
+
+  const o = M.create({ foo: "4300.20" });
+
+  const state = form.state(o, {
+    converterOptions: { decimalSeparator: ",", thousandSeparator: "." }
+  });
+  const field = state.field("foo");
+
+  await field.setRaw("5.300,20");
+  expect(field.error).toBeUndefined();
+  expect(field.raw).toEqual("5.300,20");
+  expect(field.value).toEqual("5300.20");
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -331,19 +331,14 @@ test("converter options in decimal converter in render", async () => {
     foo: new Field(converters.decimal())
   });
 
-  const o = M.create({ foo: "1234567" });
+  const o = M.create({ foo: "1234567.89" });
 
   const state = form.state(o, {
-    converterOptions: { thousandSeparator: "." }
+    converterOptions: { decimalSeparator: "," }
   });
   const field = state.field("foo");
 
-  expect(field.raw).toEqual("1.234.567");
-
-  await field.setRaw("1234568");
-  expect(field.error).toBeUndefined();
-  expect(field.raw).toEqual("1234568");
-  expect(field.value).toEqual("1234568");
+  expect(field.raw).toEqual("1234567,89");
 });
 
 test("converter options in number converter in convert", async () => {
@@ -380,14 +375,9 @@ test("converter options in number converter in render", async () => {
   const o = M.create({ foo: 1234567 });
 
   const state = form.state(o, {
-    converterOptions: { thousandSeparator: "." }
+    converterOptions: { thousandSeparator: ".", renderThousands: true }
   });
   const field = state.field("foo");
 
   expect(field.raw).toEqual("1.234.567");
-
-  await field.setRaw("1234568");
-  expect(field.error).toBeUndefined();
-  expect(field.raw).toEqual("1234568");
-  expect(field.value).toEqual(1234568);
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -300,7 +300,7 @@ test("conversionError dynamic with context", async () => {
   expect(field.error).toEqual("Not a number!!");
 });
 
-test("converter options in converter in convert", async () => {
+test("converter options in decimal converter in convert", async () => {
   const M = types.model("M", {
     foo: types.string
   });
@@ -322,7 +322,7 @@ test("converter options in converter in convert", async () => {
   expect(field.value).toEqual("5300.20");
 });
 
-test("converter options in converter in render", async () => {
+test("converter options in decimal converter in render", async () => {
   const M = types.model("M", {
     foo: types.string
   });
@@ -344,4 +344,50 @@ test("converter options in converter in render", async () => {
   expect(field.error).toBeUndefined();
   expect(field.raw).toEqual("1234568");
   expect(field.value).toEqual("1234568");
+});
+
+test("converter options in number converter in convert", async () => {
+  const M = types.model("M", {
+    foo: types.number
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.number)
+  });
+
+  const o = M.create({ foo: 4300.2 });
+
+  const state = form.state(o, {
+    converterOptions: { decimalSeparator: "," }
+  });
+  const field = state.field("foo");
+
+  await field.setRaw("5300,20");
+  expect(field.error).toBeUndefined();
+  expect(field.raw).toEqual("5300,20");
+  expect(field.value).toEqual(5300.2);
+});
+
+test("converter options in number converter in render", async () => {
+  const M = types.model("M", {
+    foo: types.number
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.number)
+  });
+
+  const o = M.create({ foo: 1234567 });
+
+  const state = form.state(o, {
+    converterOptions: { thousandSeparator: "." }
+  });
+  const field = state.field("foo");
+
+  expect(field.raw).toEqual("1.234.567");
+
+  await field.setRaw("1234568");
+  expect(field.error).toBeUndefined();
+  expect(field.raw).toEqual("1234568");
+  expect(field.value).toEqual(1234568);
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -312,12 +312,36 @@ test("converter options in converter in convert", async () => {
   const o = M.create({ foo: "4300.20" });
 
   const state = form.state(o, {
-    converterOptions: { decimalSeparator: ",", thousandSeparator: "." }
+    converterOptions: { decimalSeparator: "," }
   });
   const field = state.field("foo");
 
-  await field.setRaw("5.300,20");
+  await field.setRaw("5300,20");
   expect(field.error).toBeUndefined();
-  expect(field.raw).toEqual("5.300,20");
+  expect(field.raw).toEqual("5300,20");
   expect(field.value).toEqual("5300.20");
+});
+
+test("converter options in converter in render", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.decimal())
+  });
+
+  const o = M.create({ foo: "1234567" });
+
+  const state = form.state(o, {
+    converterOptions: { thousandSeparator: "." }
+  });
+  const field = state.field("foo");
+
+  expect(field.raw).toEqual("1.234.567");
+
+  await field.setRaw("1234568");
+  expect(field.error).toBeUndefined();
+  expect(field.raw).toEqual("1234568");
+  expect(field.value).toEqual("1234568");
 });

--- a/test/converter.test.ts
+++ b/test/converter.test.ts
@@ -10,12 +10,12 @@ test("simple converter", async () => {
     render: value => value
   });
 
-  const result = await converter.convert("foo");
+  const result = await converter.convert("foo", {});
   expect(result).toBeInstanceOf(ConversionValue);
   expect((result as ConversionValue<string>).value).toEqual("foo");
 
   // the string "ConversionError" is a valid text to convert
-  const result2 = await converter.convert("ConversionError");
+  const result2 = await converter.convert("ConversionError", {});
   expect(result2).toBeInstanceOf(ConversionValue);
   expect((result2 as ConversionValue<string>).value).toEqual("ConversionError");
 });
@@ -28,11 +28,11 @@ test("converter to integer", async () => {
     render: value => value.toString()
   });
 
-  const result = await converter.convert("3");
+  const result = await converter.convert("3", {});
   expect(result).toBeInstanceOf(ConversionValue);
   expect((result as ConversionValue<number>).value).toEqual(3);
 
-  const result2 = await converter.convert("not a number");
+  const result2 = await converter.convert("not a number", {});
   expect(result2).toEqual(CONVERSION_ERROR);
 });
 
@@ -44,11 +44,11 @@ test("converter with validate", async () => {
     validate: value => value <= 10
   });
 
-  const result = await converter.convert("3");
+  const result = await converter.convert("3", {});
   expect(result).toBeInstanceOf(ConversionValue);
   expect((result as ConversionValue<number>).value).toEqual(3);
 
-  const result2 = await converter.convert("100");
+  const result2 = await converter.convert("100", {});
   expect(result2).toEqual(CONVERSION_ERROR);
 });
 
@@ -67,7 +67,7 @@ test("converter with async validate", async () => {
     render: value => value
   });
 
-  const result = converter.convert("foo");
+  const result = converter.convert("foo", {});
   done[0]();
   const v = await result;
   expect((v as ConversionValue<string>).value).toEqual("foo");

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -56,7 +56,7 @@ test("number converter", async () => {
   await check(converters.number, "19.14", 19.14);
   await check(converters.number, "19.", 19);
   await check(converters.number, "-3.14", -3.14);
-  await checkWithOptions(converters.number, "43,14", 43.14, {
+  await checkWithOptions(converters.number, "1234,56", 1234.56, {
     decimalSeparator: ","
   });
   await checkWithOptions(converters.number, "4.314.314", 4314314, {
@@ -142,6 +142,23 @@ test("decimal converter with both options", async () => {
     decimalSeparator: ",",
     thousandSeparator: "."
   });
+});
+
+test("decimal converter render with renderThousands false", async () => {
+  const converter = converters.decimal({});
+  const options = {
+    decimalSeparator: ",",
+    thousandSeparator: ".",
+    renderThousands: false
+  };
+  const value = "4.314.314,31";
+  const processedValue = converter.preprocessRaw(value, options);
+  const converted = await converter.convert(processedValue, options);
+  const rendered = await converter.render(
+    (converted as ConversionValue<any>).value,
+    options
+  );
+  expect(rendered).toEqual("4314314,31");
 });
 
 test("boolean converter", async () => {

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -11,13 +11,13 @@ async function check(
   value: any,
   expected: any
 ) {
-  const r = await converter.convert(value);
+  const r = await converter.convert(value, {});
   expect(r).toBeInstanceOf(ConversionValue);
   expect((r as ConversionValue<any>).value).toEqual(expected);
 }
 
 async function fails(converter: IConverter<any, any>, value: any) {
-  const r = await converter.convert(value);
+  const r = await converter.convert(value, {});
   expect(r).toBe(CONVERSION_ERROR);
 }
 
@@ -86,14 +86,14 @@ test("maybe decimal converter", async () => {
   await check(converters.maybe(converters.decimal()), "3.14", "3.14");
   await check(converters.maybe(converters.decimal()), "", undefined);
   const c = converters.maybe(converters.decimal());
-  expect(c.render(undefined)).toEqual("");
+  expect(c.render(undefined, {})).toEqual("");
 });
 
 test("maybeNull decimal converter", async () => {
   await check(converters.maybeNull(converters.decimal()), "3.14", "3.14");
   await check(converters.maybeNull(converters.decimal()), "", null);
   const c = converters.maybeNull(converters.decimal());
-  expect(c.render(null)).toEqual("");
+  expect(c.render(null, {})).toEqual("");
 });
 
 test("maybe string converter", async () => {
@@ -114,9 +114,9 @@ test("model converter", async () => {
     foo: "FOO"
   });
   const converter = converters.model(M);
-  const r = await converter.convert({ foo: "value" });
+  const r = await converter.convert({ foo: "value" }, {});
   expect(r).toEqual({ value: { foo: "value" } });
-  const r2 = await converter.convert(o);
+  const r2 = await converter.convert(o, {});
   expect(r2).toEqual({ value: o });
 });
 
@@ -128,12 +128,12 @@ test("maybe model converter", async () => {
     foo: "FOO"
   });
   const converter = converters.maybe(converters.model(M));
-  const r = await converter.convert({ foo: "value" });
+  const r = await converter.convert({ foo: "value" }, {});
   expect(r).toEqual({ value: { foo: "value" } });
-  const r2 = await converter.convert(o);
+  const r2 = await converter.convert(o, {});
   expect(r2).toEqual({ value: o });
   // we use null as the sentinel value for raw
-  const r3 = await converter.convert(null);
+  const r3 = await converter.convert(null, {});
   expect(r3).toEqual({ value: undefined });
 });
 
@@ -145,11 +145,11 @@ test("maybeNull model converter", async () => {
     foo: "FOO"
   });
   const converter = converters.maybeNull(converters.model(M));
-  const r = await converter.convert({ foo: "value" });
+  const r = await converter.convert({ foo: "value" }, {});
   expect(r).toEqual({ value: { foo: "value" } });
-  const r2 = await converter.convert(o);
+  const r2 = await converter.convert(o, {});
   expect(r2).toEqual({ value: o });
-  const r3 = await converter.convert(null);
+  const r3 = await converter.convert(null, {});
   expect(r3).toEqual({ value: null });
 });
 
@@ -161,10 +161,10 @@ test("object converter", async () => {
     foo: "FOO"
   });
   const converter = converters.object;
-  const r = await converter.convert({ foo: "value" });
+  const r = await converter.convert({ foo: "value" }, {});
   expect(r).toEqual({ value: { foo: "value" } });
-  const r2 = await converter.convert(o);
+  const r2 = await converter.convert(o, {});
   expect(r2).toEqual({ value: o });
-  const r3 = await converter.convert(null);
+  const r3 = await converter.convert(null, {});
   expect(r3).toEqual({ value: null });
 });

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -79,6 +79,10 @@ test("number converter", async () => {
     decimalSeparator: ".",
     thousandSeparator: ","
   });
+  await failsWithOptions(converters.number, "1.1,1", {
+    decimalSeparator: ",",
+    thousandSeparator: "."
+  });
   await failsWithOptions(converters.number, "1,1.1", {
     decimalSeparator: ",",
     thousandSeparator: "."
@@ -138,6 +142,10 @@ test("decimal converter", async () => {
   await failsWithOptions(converters.decimal({}), "12.3,456", {
     decimalSeparator: ".",
     thousandSeparator: ","
+  });
+  await failsWithOptions(converters.decimal({}), "1.1,1", {
+    decimalSeparator: ",",
+    thousandSeparator: "."
   });
   await failsWithOptions(converters.decimal({}), "1,1.1", {
     decimalSeparator: ",",

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -79,6 +79,10 @@ test("number converter", async () => {
     decimalSeparator: ".",
     thousandSeparator: ","
   });
+  await failsWithOptions(converters.number, "1,1.1", {
+    decimalSeparator: ",",
+    thousandSeparator: "."
+  });
 });
 
 test("number converter with both options", async () => {
@@ -134,6 +138,10 @@ test("decimal converter", async () => {
   await failsWithOptions(converters.decimal({}), "12.3,456", {
     decimalSeparator: ".",
     thousandSeparator: ","
+  });
+  await failsWithOptions(converters.decimal({}), "1,1.1", {
+    decimalSeparator: ",",
+    thousandSeparator: "."
   });
 });
 

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -56,9 +56,19 @@ test("number converter", async () => {
   await check(converters.number, "19.14", 19.14);
   await check(converters.number, "19.", 19);
   await check(converters.number, "-3.14", -3.14);
+  await checkWithOptions(converters.number, "43,14", 43.14, {
+    decimalSeparator: ","
+  });
+  await checkWithOptions(converters.number, "4.314.314", 4314314, {
+    thousandSeparator: "."
+  });
   await fails(converters.number, "foo");
   await fails(converters.number, "1foo");
   await fails(converters.number, "");
+  await failsWithOptions(converters.number, "1,23.45", {
+    decimalSeparator: ".",
+    thousandSeparator: ","
+  });
 });
 
 test("integer converter", async () => {

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -72,6 +72,20 @@ test("number converter", async () => {
   await failsWithOptions(converters.number, ",12345", {
     thousandSeparator: ","
   });
+  await failsWithOptions(converters.number, "1234,567", {
+    thousandSeparator: ","
+  });
+  await failsWithOptions(converters.number, "12.3,456", {
+    decimalSeparator: ".",
+    thousandSeparator: ","
+  });
+});
+
+test("number converter with both options", async () => {
+  await checkWithOptions(converters.number, "4.314.314,31", 4314314.31, {
+    decimalSeparator: ",",
+    thousandSeparator: "."
+  });
 });
 
 test("integer converter", async () => {
@@ -113,6 +127,20 @@ test("decimal converter", async () => {
   });
   await failsWithOptions(converters.decimal({}), ",12345", {
     thousandSeparator: ","
+  });
+  await failsWithOptions(converters.decimal({}), "1234,567", {
+    thousandSeparator: ","
+  });
+  await failsWithOptions(converters.decimal({}), "12.3,456", {
+    decimalSeparator: ".",
+    thousandSeparator: ","
+  });
+});
+
+test("decimal converter with both options", async () => {
+  await checkWithOptions(converters.decimal({}), "4.314.314,31", "4314314.31", {
+    decimalSeparator: ",",
+    thousandSeparator: "."
   });
 });
 

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -69,6 +69,9 @@ test("number converter", async () => {
     decimalSeparator: ".",
     thousandSeparator: ","
   });
+  await failsWithOptions(converters.number, ",12345", {
+    thousandSeparator: ","
+  });
 });
 
 test("integer converter", async () => {
@@ -106,6 +109,9 @@ test("decimal converter", async () => {
   await fails(converters.decimal({ allowNegative: false }), "-45.34");
   await failsWithOptions(converters.decimal({}), "1,23.45", {
     decimalSeparator: ".",
+    thousandSeparator: ","
+  });
+  await failsWithOptions(converters.decimal({}), ",12345", {
     thousandSeparator: ","
   });
 });


### PR DESCRIPTION
Added converterOptions to converters. converterOptions consists of three options: decimalSeparator allows you to specify the character used to separate the integer part of a number from the fractional part. thousandSeparator allows you to specify the character used to group the thousands together. renderThousands determines whether or not the thousand separators are rendered.