### PR TITLE
Regular strings no longer convert with decimal and number converter options.

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -25,6 +25,7 @@ export interface ConverterOptions<R, V> {
   emptyRaw: R;
   defaultControlled?: Controlled;
   neverRequired?: boolean;
+  preprocessRaw?(raw: R, options?: StateConverterOptionsWithContext): R;
 }
 
 export interface IConverter<R, V> {
@@ -63,7 +64,10 @@ export class Converter<R, V> implements IConverter<R, V> {
   }
 
   preprocessRaw(raw: R, options?: StateConverterOptionsWithContext): R {
-    return raw;
+    if (this.definition.preprocessRaw == null) {
+      return raw;
+    }
+    return this.definition.preprocessRaw(raw, options);
   }
 
   async convert(

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -107,13 +107,6 @@ function renderSeparators(
 
 export class StringConverter<V> extends Converter<string, V> {
   defaultControlled = controlled.value;
-  preprocessRaw(
-    raw: string,
-    options: StateConverterOptionsWithContext
-  ): string {
-    raw = raw.trim();
-    return convertSeparators(raw, options);
-  }
 }
 
 const string = new StringConverter<string>({
@@ -123,6 +116,12 @@ const string = new StringConverter<string>({
   },
   render(value) {
     return value;
+  },
+  preprocessRaw(
+    raw: string,
+    options: StateConverterOptionsWithContext
+  ): string {
+    return raw.trim();
   }
 });
 
@@ -140,6 +139,13 @@ const number = new StringConverter<number>({
   },
   render(value, options) {
     return renderSeparators(value.toString(), options);
+  },
+  preprocessRaw(
+    raw: string,
+    options: StateConverterOptionsWithContext
+  ): string {
+    raw = raw.trim();
+    return convertSeparators(raw, options);
   }
 });
 
@@ -153,6 +159,12 @@ const integer = new StringConverter<number>({
   },
   render(value) {
     return value.toString();
+  },
+  preprocessRaw(
+    raw: string,
+    options: StateConverterOptionsWithContext
+  ): string {
+    return raw.trim();
   }
 });
 

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -12,7 +12,8 @@ async function check(
   value: any,
   expected: any
 ) {
-  const r = await converter.convert(value, {});
+  const processedValue = converter.preprocessRaw(value, {});
+  const r = await converter.convert(processedValue, {});
   expect(r).toBeInstanceOf(ConversionValue);
   expect((r as ConversionValue<any>).value).toEqual(expected);
 }
@@ -175,6 +176,12 @@ test("decimal converter render with renderThousands false", async () => {
     options
   );
   expect(rendered).toEqual("4314314,31");
+});
+
+test("do not convert a normal string with decimal options", async () => {
+  await checkWithOptions(converters.string, "43,14", "43,14", {
+    decimalSeparator: ","
+  });
 });
 
 test("boolean converter", async () => {


### PR DESCRIPTION
Previously, all strings raws were preprocessed with converter options. This no longer happens.