### PR TITLE
Fix preprocessRaw in StringMaybe.

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -117,10 +117,7 @@ const string = new StringConverter<string>({
   render(value) {
     return value;
   },
-  preprocessRaw(
-    raw: string,
-    options: StateConverterOptionsWithContext
-  ): string {
+  preprocessRaw(raw: string): string {
     return raw.trim();
   }
 });
@@ -160,10 +157,7 @@ const integer = new StringConverter<number>({
   render(value) {
     return value.toString();
   },
-  preprocessRaw(
-    raw: string,
-    options: StateConverterOptionsWithContext
-  ): string {
+  preprocessRaw(raw: string): string {
     return raw.trim();
   }
 });
@@ -306,8 +300,12 @@ class StringMaybe<V, RE, VE> implements IConverter<string, V | VE> {
     this.emptyRaw = "";
   }
 
-  preprocessRaw(raw: string): string {
-    return raw.trim();
+  preprocessRaw(
+    raw: string,
+    options: StateConverterOptionsWithContext
+  ): string {
+    raw = raw.trim();
+    return this.converter.preprocessRaw(raw, options);
   }
 
   async convert(

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -123,6 +123,16 @@ test("decimal converter", async () => {
   await checkWithOptions(converters.decimal({}), "4.314.314", "4314314", {
     thousandSeparator: "."
   });
+  await checkWithOptions(
+    converters.decimal({ decimalPlaces: 2 }),
+    "36.365,21",
+    "36365.21",
+    {
+      decimalSeparator: ",",
+      thousandSeparator: ".",
+      renderThousands: true
+    }
+  );
   await fails(converters.decimal({}), "foo");
   await fails(converters.decimal({}), "1foo");
   await fails(converters.decimal({}), "");


### PR DESCRIPTION
StringMaybe was using the old preprocessRaw behaviour and would never implement the new behaviour for numbers and decimals. This has now been fixed.