### PR TITLE
RequiredError on state.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.3.0
+
+-   Added `requiredError` behaviour to the form state. You can now set an error
+    message directly on the state. This will be applied to every field, unless
+    you specify `requiredError` on a field itself.
+
 # 1.2.1
 
 -   Fixed a bug where `converterOptions` were too aggressive and applied to

--- a/README.md
+++ b/README.md
@@ -861,6 +861,16 @@ const form = new Form(M, {
 });
 ```
 
+`requiredError` can also be set on the state, where it will be applied to every
+field on the form unless you control the required error message on the field, in
+which case it will ignore the state's general configuration:
+
+```js
+this.formState = form.state(o, {
+    requiredError: "This is required!"
+});
+```
+
 ## Dynamic disabled, hidden, required and readOnly fields
 
 mstform has hooks that let you calculate `hidden`, `disabled`, `required` and

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -266,6 +266,7 @@ export class FieldAccessor<R, V> {
         raw,
         this.required,
         this.state.stateConverterOptionsWithContext,
+        this.state._requiredError,
         options
       );
     } catch (e) {

--- a/src/form.ts
+++ b/src/form.ts
@@ -206,7 +206,13 @@ export class Field<R, V> {
     throw new Error("This is a function to enable type introspection");
   }
 
-  getRequiredError(context: any): string {
+  getRequiredError(context: any, requiredError?: string | ErrorFunc): string {
+    if (requiredError != null) {
+      if (typeof requiredError === "string") {
+        return requiredError;
+      }
+      return requiredError(context);
+    }
     if (typeof this.requiredError === "string") {
       return this.requiredError;
     }
@@ -224,6 +230,7 @@ export class Field<R, V> {
     raw: R,
     required: boolean,
     stateConverterOptions: StateConverterOptionsWithContext,
+    requiredError?: string | ErrorFunc,
     options?: ProcessOptions
   ): Promise<ProcessResponse<V>> {
     raw = this.converter.preprocessRaw(raw, stateConverterOptions);
@@ -235,7 +242,7 @@ export class Field<R, V> {
       required
     ) {
       return new ValidationMessage(
-        this.getRequiredError(stateConverterOptions.context)
+        this.getRequiredError(stateConverterOptions.context, requiredError)
       );
     }
 
@@ -254,7 +261,7 @@ export class Field<R, V> {
       // is implied to be required
       if (raw === this.converter.emptyRaw) {
         return new ValidationMessage(
-          this.getRequiredError(stateConverterOptions.context)
+          this.getRequiredError(stateConverterOptions.context, requiredError)
         );
       }
       return new ValidationMessage(

--- a/src/form.ts
+++ b/src/form.ts
@@ -206,17 +206,18 @@ export class Field<R, V> {
     throw new Error("This is a function to enable type introspection");
   }
 
-  getRequiredError(context: any, requiredError: string | ErrorFunc): string {
-    if (this.requiredError != null) {
-      if (typeof this.requiredError === "string") {
-        return this.requiredError;
-      }
-      return this.requiredError(context);
-    }
+  requiredErrorType(context: any, requiredError: string | ErrorFunc): string {
     if (typeof requiredError === "string") {
       return requiredError;
     }
     return requiredError(context);
+  }
+
+  getRequiredError(context: any, requiredError: string | ErrorFunc): string {
+    if (this.requiredError != null) {
+      return this.requiredErrorType(context, this.requiredError);
+    }
+    return this.requiredErrorType(context, requiredError);
   }
 
   getConversionError(context: any): string {

--- a/src/form.ts
+++ b/src/form.ts
@@ -145,7 +145,7 @@ export class Field<R, V> {
   rawValidators: Validator<R>[];
   validators: Validator<V>[];
   conversionError: string | ErrorFunc;
-  requiredError: string | ErrorFunc;
+  requiredError?: string | ErrorFunc;
   required: boolean;
   getRaw: RawGetter<R>;
   derivedFunc?: Derived<V>;
@@ -160,7 +160,7 @@ export class Field<R, V> {
       this.rawValidators = [];
       this.validators = [];
       this.conversionError = "Could not convert";
-      this.requiredError = "Required";
+      this.requiredError = undefined;
       this.required = false;
       this.getRaw = identity;
       this.controlled = this.createDefaultControlled();
@@ -168,7 +168,7 @@ export class Field<R, V> {
       this.rawValidators = options.rawValidators ? options.rawValidators : [];
       this.validators = options.validators ? options.validators : [];
       this.conversionError = options.conversionError || "Could not convert";
-      this.requiredError = options.requiredError || "Required";
+      this.requiredError = options.requiredError || undefined;
       this.required = options.required || false;
       if (options.fromEvent) {
         if (options.getRaw) {
@@ -206,17 +206,17 @@ export class Field<R, V> {
     throw new Error("This is a function to enable type introspection");
   }
 
-  getRequiredError(context: any, requiredError?: string | ErrorFunc): string {
-    if (requiredError != null) {
-      if (typeof requiredError === "string") {
-        return requiredError;
+  getRequiredError(context: any, requiredError: string | ErrorFunc): string {
+    if (this.requiredError != null) {
+      if (typeof this.requiredError === "string") {
+        return this.requiredError;
       }
-      return requiredError(context);
+      return this.requiredError(context);
     }
-    if (typeof this.requiredError === "string") {
-      return this.requiredError;
+    if (typeof requiredError === "string") {
+      return requiredError;
     }
-    return this.requiredError(context);
+    return requiredError(context);
   }
 
   getConversionError(context: any): string {
@@ -230,7 +230,7 @@ export class Field<R, V> {
     raw: R,
     required: boolean,
     stateConverterOptions: StateConverterOptionsWithContext,
-    requiredError?: string | ErrorFunc,
+    requiredError: string | ErrorFunc,
     options?: ProcessOptions
   ): Promise<ProcessResponse<V>> {
     raw = this.converter.preprocessRaw(raw, stateConverterOptions);

--- a/src/state.ts
+++ b/src/state.ts
@@ -125,7 +125,7 @@ export class FormState<
 
   _context: any;
   _converterOptions: StateConverterOptions;
-  _requiredError?: string | ErrorFunc;
+  _requiredError: string | ErrorFunc;
 
   constructor(
     public form: Form<M, D, G>,
@@ -176,7 +176,7 @@ export class FormState<
       this.updateFunc = null;
       this._context = undefined;
       this._converterOptions = {};
-      this._requiredError = undefined;
+      this._requiredError = "Required";
     } else {
       this.saveFunc = options.save ? options.save : defaultSaveFunc;
       this.isDisabledFunc = options.isDisabled
@@ -208,7 +208,7 @@ export class FormState<
       this.updateFunc = options.update ? options.update : null;
       this._context = options.context;
       this._converterOptions = options.converterOptions || {};
-      this._requiredError = options.requiredError || undefined;
+      this._requiredError = options.requiredError || "Required";
     }
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,7 +11,8 @@ import {
   Form,
   FormDefinitionForModel,
   ValidationResponse,
-  GroupDefinition
+  GroupDefinition,
+  ErrorFunc
 } from "./form";
 import {
   deepCopy,
@@ -88,6 +89,7 @@ export interface FormStateOptions<M> {
 
   context?: any;
   converterOptions?: StateConverterOptions;
+  requiredError?: string | ErrorFunc;
 }
 
 export type SaveStatusOptions = "before" | "rightAfter" | "after";
@@ -123,6 +125,7 @@ export class FormState<
 
   _context: any;
   _converterOptions: StateConverterOptions;
+  _requiredError?: string | ErrorFunc;
 
   constructor(
     public form: Form<M, D, G>,
@@ -173,6 +176,7 @@ export class FormState<
       this.updateFunc = null;
       this._context = undefined;
       this._converterOptions = {};
+      this._requiredError = undefined;
     } else {
       this.saveFunc = options.save ? options.save : defaultSaveFunc;
       this.isDisabledFunc = options.isDisabled
@@ -204,6 +208,7 @@ export class FormState<
       this.updateFunc = options.update ? options.update : null;
       this._context = options.context;
       this._converterOptions = options.converterOptions || {};
+      this._requiredError = options.requiredError || undefined;
     }
   }
 

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1079,6 +1079,57 @@ test("required with save", async () => {
   expect(field.error).toEqual("Required");
 });
 
+test("required with requiredError", async () => {
+  const M = types.model("M", {
+    foo: types.number
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.number, {
+      required: true
+    })
+  });
+
+  const o = M.create({ foo: 3 });
+
+  const state = form.state(o, { requiredError: "Verplicht" });
+
+  const field = state.field("foo");
+
+  expect(field.raw).toEqual("3");
+  expect(field.value).toEqual(3);
+  await field.setRaw("");
+  expect(field.error).toEqual("Verplicht");
+  expect(field.value).toEqual(3);
+});
+
+test("required with context in requiredError", async () => {
+  const M = types.model("M", {
+    foo: types.number
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.number, {
+      required: true
+    })
+  });
+
+  const o = M.create({ foo: 3 });
+
+  const state = form.state(o, {
+    context: "!",
+    requiredError: context => "Verplicht" + context
+  });
+
+  const field = state.field("foo");
+
+  expect(field.raw).toEqual("3");
+  expect(field.value).toEqual(3);
+  await field.setRaw("");
+  expect(field.error).toEqual("Verplicht!");
+  expect(field.value).toEqual(3);
+});
+
 test("dynamic required with save", async () => {
   const M = types.model("M", {
     foo: types.string,

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1130,6 +1130,34 @@ test("required with context in requiredError", async () => {
   expect(field.value).toEqual(3);
 });
 
+test("required with requiredError on state and on field", async () => {
+  const M = types.model("M", {
+    foo: types.number
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.number, {
+      required: true,
+      requiredError: "This is required"
+    })
+  });
+
+  const o = M.create({ foo: 3 });
+
+  const state = form.state(o, {
+    context: "!",
+    requiredError: "This is not required"
+  });
+
+  const field = state.field("foo");
+
+  expect(field.raw).toEqual("3");
+  expect(field.value).toEqual(3);
+  await field.setRaw("");
+  expect(field.error).toEqual("This is required");
+  expect(field.value).toEqual(3);
+});
+
 test("dynamic required with save", async () => {
   const M = types.model("M", {
     foo: types.string,


### PR DESCRIPTION
You can now set requiredError directly on the form state. This will influence all fields in the form, except for fields that explicitly set a different error message.