### PR TITLE
More value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
+# 1.4.0
+
+-   Added 'value' to all the accessor. This is the underlying value that the
+    accessor is working on (a MST node for `SubForm` and
+    `RepeatingFormIndexAccessor` and a MST array in case of
+    `RepeatingFormAccessor`). This allows you hooks (such as `isRequired`)
+    that takes the value into account.
+
 # 1.3.0
 
--   Added `requiredError` behaviour to the form state. You can now set an error
+-   Added `requiredError` behavior to the form state. You can now set an error
     message directly on the state. This will be applied to every field, unless
     you specify `requiredError` on a field itself.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 # 1.4.0
 
--   Added 'value' to all the accessor. This is the underlying value that the
+-   Added 'value' to all the accessors. This is the underlying value that the
     accessor is working on (a MST node for `SubForm` and
     `RepeatingFormIndexAccessor` and a MST array in case of
-    `RepeatingFormAccessor`). This allows you hooks (such as `isRequired`)
-    that takes the value into account.
+    `RepeatingFormAccessor`). This allows you hooks (such as `isRequired`) that
+    takes the value into account.
 
 # 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,60 @@ const description = state.field("description");
 const name = state.subForm("pet").field("name");
 ```
 
+## Accessors
+
+mstform defines a bunch of accessors:
+
+-   `FieldAccessor`, which you define with `Field` and get with `field()`. This
+    represents a field in the form that you can actually fill in and interact
+    with.
+
+-   `SubFormAccessor` which you define with `SubForm` and get with `subForm()`.
+    This represents a sub-object in the underlying model instance.
+
+-   `RepeatingFormAccessor` which you define with `RepeatingForm` and get with
+    `repeatingForm()`. This represents an array of objects in the underlying
+    model instance.
+
+-   `RepeatingFormIndexedAccessor` which you define along with
+    `RepeatingFormAccessor` using `RepeatingForm`. You access it via the
+    `index()` method on a `RepeatingFormAccessor`. This represents a sub-object
+    in the underlying array instance.
+
+-   `GroupAccessor`. You define this in a second argument on forms. You can
+    access it via the `group()` method on any form accessor. This is a special
+    kind of accessor that only implements an `isValid` method. It's a way to
+    aggregate validation results from other accessors.
+
+-   Finally there is the `FormState` itself, which is the accessor at the root of
+    all things. You get it with `form.state()`.
+
+Accessors can contain other accessors. In particular, `FormState`,
+`SubFormAccessor` and `RepeatingFormIndexedAccessor` allow you to access all
+varieties of sub-accessor on it (except for `FormState` itself).
+`RepeatingFormAccessor` allows only a single kind of sub-accessor, namely
+`RepeatingFormIndexedAccessor`, which you access via `index()`. You cannot
+access any sub-accessors on `FieldAccessor`. `GroupAccessor` doesn't allow
+you access sub-accessors either.
+
+All these accessors, except for `GroupAccessor` which is truly the odd one out,
+have some properties in common:
+
+-   `value`: the underlying MST value that this accessor represents.
+
+-   `path`: The JSON path to the underlying MST value (see mobx-state-tree).
+
+-   `context`: The context object such as passed into `form.state()`.
+
+-   `isValid`: Is true if the accessor (and all its sub-accessors) is valid.
+
+-   `error`: An error message (or `undefined`). Note that errors on non-field
+    accessors can only be set by external means such as with the `getERror`
+    hook.
+
+-   `warning`: A warning message (or `undefined`). Warning messages can only
+    be set using the `getWarning` hook.
+
 ## Supported converters
 
 A converter specifies how to convert a raw value as it is entered in the form

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -4,7 +4,8 @@ import {
   RepeatingFormGroupDefinitionType,
   SubFormDefinitionType,
   SubFormGroupDefinitionType,
-  RawType
+  RawType,
+  ValueType
 } from "./form";
 import { FieldAccessor } from "./field-accessor";
 import { FormAccessor } from "./form-accessor";
@@ -26,7 +27,7 @@ export type Accessor =
 export type FieldAccess<
   D extends FormDefinition<any>,
   K extends keyof D
-> = FieldAccessor<RawType<D[K]>, D[K]>;
+> = FieldAccessor<RawType<D[K]>, ValueType<D[K]>>;
 
 export type RepeatingFormAccess<
   D extends FormDefinition<any>,
@@ -44,4 +45,4 @@ export type SubFormAccess<
   SubFormGroupDefinitionType<D[K]>
 >;
 
-export type GroupAccess<M, D extends FormDefinition<M>> = GroupAccessor<M, D>;
+export type GroupAccess<D extends FormDefinition<any>> = GroupAccessor<D>;

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -81,7 +81,7 @@ export abstract class FormAccessorBase<
     return this.formAccessor.subForm(name);
   }
 
-  group<K extends keyof G>(name: K): GroupAccess<any, D> {
+  group<K extends keyof G>(name: K): GroupAccess<D> {
     return this.formAccessor.group(name);
   }
 

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -1,4 +1,5 @@
-import { observable, computed, action } from "mobx";
+import { observable, computed } from "mobx";
+
 import {
   SubForm,
   Field,
@@ -33,7 +34,7 @@ export class FormAccessor<
     RepeatingFormAccessor<any, any>
   > = observable.map();
   subFormAccessors: Map<keyof D, SubFormAccessor<any, any>> = observable.map();
-  groupAccessors: Map<keyof G, GroupAccessor<any, any>> = observable.map();
+  groupAccessors: Map<keyof G, GroupAccessor<any>> = observable.map();
 
   @observable
   _addMode: boolean;
@@ -75,6 +76,11 @@ export class FormAccessor<
       return "";
     }
     return this.parent.path;
+  }
+
+  @computed
+  get value(): any {
+    return this.state.getValue(this.path);
   }
 
   @computed
@@ -248,7 +254,7 @@ export class FormAccessor<
     this.groupAccessors.set(name, result);
   }
 
-  group<K extends keyof G>(name: K): GroupAccess<any, D> {
+  group<K extends keyof G>(name: K): GroupAccess<D> {
     const accessor = this.groupAccessors.get(name);
     if (accessor == null) {
       throw new Error(`${name} is not a Group`);

--- a/src/form.ts
+++ b/src/form.ts
@@ -1,8 +1,7 @@
-import { IObservableArray } from "mobx";
 import {
-  IModelType,
+  IMSTArray,
   IAnyModelType,
-  ModelInstanceTypeProps,
+  ModelInstanceType,
   Instance
 } from "mobx-state-tree";
 import { CONVERSION_ERROR, IConverter } from "./converter";
@@ -10,19 +9,11 @@ import { FormState, FormStateOptions } from "./state";
 import { Controlled } from "./controlled";
 import { identity } from "./utils";
 
-// XXX copied from MST as it doesn't export it
-export type ExtractProps<T extends IAnyModelType> = T extends IModelType<
-  infer P,
-  any,
-  any,
-  any
->
-  ? P
-  : never;
-
-export type ArrayEntryType<T> = T extends IObservableArray<infer A> ? A : never;
+export type ArrayEntryType<T> = T extends IMSTArray<infer A> ? A : never;
 
 export type RawType<F> = F extends Field<infer R, any> ? R : never;
+
+export type ValueType<F> = F extends Field<any, infer V> ? V : never;
 
 export type RepeatingFormDefinitionType<T> = T extends RepeatingForm<
   infer D,
@@ -46,16 +37,18 @@ export type SubFormGroupDefinitionType<T> = T extends SubForm<any, infer G>
   ? G
   : never;
 
-export type FormDefinitionEntry<M, K extends keyof M> =
-  | Field<any, M[K]>
-  | RepeatingForm<FormDefinition<ArrayEntryType<M[K]>>, GroupDefinition<any>>
-  | SubForm<FormDefinition<M[K]>, GroupDefinition<any>>;
-
-export type FormDefinition<M> = { [K in keyof M]?: FormDefinitionEntry<M, K> };
-
-export type FormDefinitionForModel<P extends IAnyModelType> = FormDefinition<
-  ModelInstanceTypeProps<ExtractProps<P>>
+export type FormDefinition<M extends IAnyModelType> = InstanceFormDefinition<
+  Instance<M>
 >;
+
+export type InstanceFormDefinition<
+  M extends ModelInstanceType<any, any, any, any>
+> = {
+  [K in keyof M]?:
+    | Field<any, M[K]>
+    | RepeatingForm<InstanceFormDefinition<ArrayEntryType<M[K]>>, any>
+    | SubForm<FormDefinition<M[K]>, any>
+};
 
 export type ValidationResponse = string | null | undefined | false;
 
@@ -98,7 +91,7 @@ export type GroupDefinition<D extends FormDefinition<any>> = {
 
 export class Form<
   M extends IAnyModelType,
-  D extends FormDefinitionForModel<M>,
+  D extends FormDefinition<M>,
   G extends GroupDefinition<D>
 > {
   constructor(

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -3,7 +3,7 @@ import { FormDefinition, Group } from "./form";
 import { FormState } from "./state";
 import { FormAccessor } from "./form-accessor";
 
-export class GroupAccessor<M, D extends FormDefinition<M>> {
+export class GroupAccessor<D extends FormDefinition<any>> {
   constructor(
     public state: FormState<any, any, any>,
     public definition: D,

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -1,5 +1,5 @@
 import { observable, computed } from "mobx";
-import { applyPatch, resolvePath } from "mobx-state-tree";
+import { applyPatch } from "mobx-state-tree";
 import { FormDefinition, RepeatingForm, GroupDefinition } from "./form";
 import { FormState } from "./state";
 import { Accessor } from "./accessor";
@@ -32,6 +32,11 @@ export class RepeatingFormAccessor<
   @computed
   get path(): string {
     return this.parent.path + "/" + this.name;
+  }
+
+  @computed
+  get value(): any {
+    return this.state.getValue(this.path);
   }
 
   @computed
@@ -136,7 +141,7 @@ export class RepeatingFormAccessor<
   }
 
   push(node: any) {
-    const a = resolvePath(this.state.node, this.path) as any[];
+    const a = this.value;
     const index = a.length;
     const path = this.path + "/" + index;
     applyPatch(this.state.node, [{ op: "add", path, value: node }]);
@@ -144,7 +149,7 @@ export class RepeatingFormAccessor<
   }
 
   remove(node: any) {
-    const a = resolvePath(this.state.node, this.path) as any[];
+    const a = this.value;
     const index = a.indexOf(node);
     if (index === -1) {
       throw new Error("Cannot find node to remove.");
@@ -207,9 +212,9 @@ export class RepeatingFormAccessor<
     });
   }
 
+  @computed
   get length(): number {
-    const a = resolvePath(this.state.node, this.path) as any[];
-    return a.length;
+    return this.value.length;
   }
 
   @computed

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -1,4 +1,5 @@
 import { action, observable, computed } from "mobx";
+
 import { FormDefinition, GroupDefinition } from "./form";
 import { FormState } from "./state";
 import { RepeatingFormAccessor } from "./repeating-form-accessor";
@@ -45,6 +46,11 @@ export class RepeatingFormIndexedAccessor<
   @computed
   get path(): string {
     return this.parent.path + "/" + this.index;
+  }
+
+  @computed
+  get value(): any {
+    return this.state.getValue(this.path);
   }
 
   @action

--- a/src/state.ts
+++ b/src/state.ts
@@ -9,7 +9,7 @@ import {
 import { Accessor } from "./accessor";
 import {
   Form,
-  FormDefinitionForModel,
+  FormDefinition,
   ValidationResponse,
   GroupDefinition
 } from "./form";
@@ -89,7 +89,7 @@ export type SaveStatusOptions = "before" | "rightAfter" | "after";
 
 export class FormState<
   M extends IAnyModelType,
-  D extends FormDefinitionForModel<M>,
+  D extends FormDefinition<M>,
   G extends GroupDefinition<D>
 > extends FormAccessorBase<D, G> {
   @observable
@@ -202,6 +202,11 @@ export class FormState<
   @computed
   get context(): any {
     return this._context;
+  }
+
+  @computed
+  get value(): Instance<M> {
+    return this.node;
   }
 
   @action

--- a/src/state.ts
+++ b/src/state.ts
@@ -218,6 +218,11 @@ export class FormState<
   }
 
   @computed
+  get path(): string {
+    return "/";
+  }
+
+  @computed
   get value(): Instance<M> {
     return this.node;
   }

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -49,6 +49,11 @@ export class SubFormAccessor<
   }
 
   @computed
+  get value(): any {
+    return this.state.getValue(this.path);
+  }
+
+  @computed
   get addMode(): boolean {
     return this.parent.addMode;
   }

--- a/test/navigate.test.ts
+++ b/test/navigate.test.ts
@@ -1,0 +1,90 @@
+import { configure } from "mobx";
+import { types, getType } from "mobx-state-tree";
+import { Field, Form, SubForm, RepeatingForm, converters } from "../src";
+
+// "always" leads to trouble during initialization.
+configure({ enforceActions: "observed" });
+
+test("value for state", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const state = form.state(o);
+  expect(state.value).toBe(o);
+});
+
+test("value for sub form", async () => {
+  const N = types
+    .model("N", {
+      bar: types.string
+    })
+    .views(self => ({
+      something() {
+        return self.bar + "X";
+      }
+    }));
+
+  const M = types.model("M", {
+    foo: N
+  });
+
+  const form = new Form(M, {
+    foo: new SubForm({
+      bar: new Field(converters.string)
+    })
+  });
+
+  const o = M.create({ foo: { bar: "BAR" } });
+
+  const state = form.state(o);
+  const sub = state.subForm("foo");
+
+  expect(sub.value).toBe(o.foo);
+  expect(getType(sub.value)).toBe(N);
+  expect(sub.value.something()).toEqual("BARX");
+  expect(getType(sub.parent.value)).toBe(M);
+});
+
+test("value for repeating form", async () => {
+  const N = types
+    .model("N", {
+      bar: types.string
+    })
+    .views(self => ({
+      something() {
+        return self.bar + "X";
+      }
+    }));
+
+  const M = types.model("M", {
+    foo: types.array(N)
+  });
+
+  const form = new Form(M, {
+    foo: new RepeatingForm({
+      bar: new Field(converters.string)
+    })
+  });
+
+  const o = M.create({ foo: [{ bar: "BAR" }] });
+
+  const state = form.state(o);
+  const forms = state.repeatingForm("foo");
+
+  expect(forms.value).toEqual(o.foo);
+
+  const first = forms.index(0);
+
+  expect(first.value).toBe(o.foo[0]);
+  expect(getType(first.value)).toBe(N);
+  expect(first.value.something()).toEqual("BARX");
+  expect(getType(first.parent.value)).toEqual(types.array(N));
+  expect(getType(first.parent.parent.value)).toBe(M);
+});


### PR DESCRIPTION
Introduce 'value' on all accessors (except for GroupAccessor).

Better document the accessors story.

Improve the way we define typings. I couldn't get it to determine the type for 'value' yet unfortunately -- this might require a change to how we define sub-forms in general.

Simplify the type for GroupAccessor (no more M generic type argument)