### PR TITLE
Required rework

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,16 @@
     `RepeatingFormAccessor`). This allows you hooks (such as `isRequired`) that
     takes the value into account.
 
+-   When you have a field that has an possible empty value (i.e. a MST
+    `types.string`, or one that uses `types.maybe` or `types.maybeNull`), and
+    you require this field (either statically or dynamically), and you then
+    make the raw value empty, the underlying value is set to its empty value as
+    well, even though you get a `required` error at the same time.
+
+-   You can mark a custom converter `emptyImpossible`, or supply an
+    `emptyValue`. This way mstform can deduce whether a field can be emptied at
+    all, and what the empty value is.
+
 # 1.3.0
 
 -   Added `requiredError` behavior to the form state. You can now set an error

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
     `RepeatingFormAccessor`). This allows you hooks (such as `isRequired`) that
     takes the value into account.
 
--   When you have a field that has an possible empty value (i.e. a MST
+-   When you have a field that has a possible empty value (i.e. a MST
     `types.string`, or one that uses `types.maybe` or `types.maybeNull`), and
     you require this field (either statically or dynamically), and you then
     make the raw value empty, the underlying value is set to its empty value as

--- a/README.md
+++ b/README.md
@@ -1190,7 +1190,3 @@ const state = form.state(o, {
 
 -   Don't name your form state `this.state` on a React component as this has a
     special meaning to React and can lead to odd bugs.
-
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -889,18 +889,35 @@ field definition:
 
 ```js
 const form = new Form(M, {
-    nr: new Field(converters.number, { required: true })
+    name: new Field(converters.string, { required: true })
 });
 ```
 
-This causes the field accessor's `required` property to be `true`, which you
-can use during form rendering. It also causes it to be a validation error
-if the field isn't filled in. You can control the required error message
-by setting `requiredError`:
+This causes `required` property of the field accessor to be `true`, which you
+can use during form rendering. It also causes it to be a validation error if
+the field isn't filled in.
+
+When the user enters an empty value (for instance the empty string), mstform
+empties the underlying value if possible, changing the underlying object. This
+is possible for the form defined above, as it uses a string converter (which can
+be empty). A number converter cannot be empty however:
 
 ```js
 const form = new Form(M, {
-    nr: new Field(converters.number, {
+    nr: new Field(converters.number)
+});
+```
+
+In this case, the user _has_ to fill in a raw value that can be converted to a
+number, otherwise the user gets the required error message and the underlying
+value is not updated. Note that the `required` configuration in this case is
+optional as it's implied by `converters.number`.
+
+You can control the required error message by setting `requiredError`:
+
+```js
+const form = new Form(M, {
+    name: new Field(converters.string, {
         required: true,
         requiredError: "This is required!"
     })
@@ -912,7 +929,7 @@ You can also set `requiredError` to a function, in which cases it receives a
 
 ```js
 const form = new Form(M, {
-    nr: new Field(converters.number, {
+    name: new Field(converters.string, {
         required: true,
         requiredError: context =>
             context.language === "en"
@@ -922,9 +939,9 @@ const form = new Form(M, {
 });
 ```
 
-`requiredError` can also be set on the state, where it will be applied to every
-field on the form unless you control the required error message on the field, in
-which case it will ignore the state's general configuration:
+`requiredError` (as a message or a function) can also be set on the state,
+where it will be applied to every field on the form unless you override the
+required error message on the field:
 
 ```js
 this.formState = form.state(o, {

--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ takes a text in the UI and considers `"t"` as `true` and the rest as
 ```ts
 const boolean = new Converter<string, boolean>({
     emptyRaw: "f",
+    emptyImpossible: true,
     convert(raw) {
         return raw === "t";
     },
@@ -480,7 +481,13 @@ whether the raw value is valid. `validate` is an optional function that checks
 whether the value is valid.
 
 `emptyRaw` is the raw value that should be shown if the field is empty in the
-UI.
+UI. We also set `emptyImpossible` -- it's impossible for the result of this
+conversion to be empty (it's either `true` or `false`). In other cases,
+an empty value can exist: for instance a converter to a string could produce
+the empty string, or a maybe converter can produce `undefined`. In this
+case you need to set the `emptyValue` property to what the value is when
+it's not filled in. It's not allowed to set `emptyValue` when you
+also define `emptyImpossible` to be `true`.
 
 You can optionally set `defaultControlled`, the controlled props to be used by
 default for this converter. You can also optionally set `neverRequired`; this

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -23,6 +23,7 @@ export interface ConverterOptions<R, V> {
     options: StateConverterOptionsWithContext
   ): boolean | Promise<boolean>;
   emptyRaw: R;
+  emptyImpossible?: boolean;
   defaultControlled?: Controlled;
   neverRequired?: boolean;
   preprocessRaw?(raw: R, options?: StateConverterOptionsWithContext): R;
@@ -30,6 +31,7 @@ export interface ConverterOptions<R, V> {
 
 export interface IConverter<R, V> {
   emptyRaw: R;
+  emptyImpossible: boolean;
   convert(
     raw: R,
     options: StateConverterOptionsWithContext
@@ -52,6 +54,7 @@ export type ConversionResponse<V> = ConversionError | ConversionValue<V>;
 
 export class Converter<R, V> implements IConverter<R, V> {
   emptyRaw: R;
+  emptyImpossible: boolean;
   defaultControlled: Controlled;
   neverRequired: boolean = false;
 
@@ -61,6 +64,7 @@ export class Converter<R, V> implements IConverter<R, V> {
       ? definition.defaultControlled
       : controlled.object;
     this.neverRequired = !!definition.neverRequired;
+    this.emptyImpossible = !!definition.emptyImpossible;
   }
 
   preprocessRaw(raw: R, options?: StateConverterOptionsWithContext): R {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -23,7 +23,7 @@ export interface ConverterOptions<R, V> {
     options: StateConverterOptionsWithContext
   ): boolean | Promise<boolean>;
   emptyRaw: R;
-  emptyValue: V;
+  emptyValue?: V;
   emptyImpossible?: boolean;
   defaultControlled?: Controlled;
   neverRequired?: boolean;
@@ -63,12 +63,22 @@ export class Converter<R, V> implements IConverter<R, V> {
 
   constructor(public definition: ConverterOptions<R, V>) {
     this.emptyRaw = definition.emptyRaw;
-    this.emptyValue = definition.emptyValue;
+    this.emptyImpossible = !!definition.emptyImpossible;
+    const emptyValue = definition.emptyValue;
+    if (this.emptyImpossible) {
+      if (emptyValue !== undefined) {
+        throw new Error(
+          "If you set emptyImpossible for a converter, emptyValue cannot be set"
+        );
+      }
+      this.emptyValue = undefined as any;
+    } else {
+      this.emptyValue = emptyValue as any;
+    }
     this.defaultControlled = definition.defaultControlled
       ? definition.defaultControlled
       : controlled.object;
     this.neverRequired = !!definition.neverRequired;
-    this.emptyImpossible = !!definition.emptyImpossible;
   }
 
   preprocessRaw(raw: R, options?: StateConverterOptionsWithContext): R {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -23,6 +23,7 @@ export interface ConverterOptions<R, V> {
     options: StateConverterOptionsWithContext
   ): boolean | Promise<boolean>;
   emptyRaw: R;
+  emptyValue: V;
   emptyImpossible?: boolean;
   defaultControlled?: Controlled;
   neverRequired?: boolean;
@@ -31,6 +32,7 @@ export interface ConverterOptions<R, V> {
 
 export interface IConverter<R, V> {
   emptyRaw: R;
+  emptyValue: V;
   emptyImpossible: boolean;
   convert(
     raw: R,
@@ -54,12 +56,14 @@ export type ConversionResponse<V> = ConversionError | ConversionValue<V>;
 
 export class Converter<R, V> implements IConverter<R, V> {
   emptyRaw: R;
+  emptyValue: V;
   emptyImpossible: boolean;
   defaultControlled: Controlled;
   neverRequired: boolean = false;
 
   constructor(public definition: ConverterOptions<R, V>) {
     this.emptyRaw = definition.emptyRaw;
+    this.emptyValue = definition.emptyValue;
     this.defaultControlled = definition.defaultControlled
       ? definition.defaultControlled
       : controlled.object;

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -110,6 +110,7 @@ export class StringConverter<V> extends Converter<string, V> {
 
 const string = new StringConverter<string>({
   emptyRaw: "",
+  emptyValue: "",
   emptyImpossible: false,
   convert(raw) {
     return raw;
@@ -125,6 +126,7 @@ const string = new StringConverter<string>({
 const number = new StringConverter<number>({
   emptyRaw: "",
   emptyImpossible: true,
+  emptyValue: 1, // arbitrary as impossible
   rawValidate(raw) {
     // deal with case when string starts with .
     if (raw.startsWith(".")) {
@@ -150,6 +152,7 @@ const number = new StringConverter<number>({
 const integer = new StringConverter<number>({
   emptyRaw: "",
   emptyImpossible: true,
+  emptyValue: 1, // arbitrary as impossible
   rawValidate(raw) {
     return INTEGER_REGEX.test(raw);
   },
@@ -167,6 +170,7 @@ const integer = new StringConverter<number>({
 const boolean = new Converter<boolean, boolean>({
   emptyRaw: false,
   emptyImpossible: true,
+  emptyValue: false, // arbitrary as impossible
   convert(raw) {
     return raw;
   },
@@ -201,6 +205,7 @@ function decimal(options?: DecimalOptions) {
   return new StringConverter<string>({
     emptyRaw: "",
     emptyImpossible: true,
+    emptyValue: "", // arbitrary as impossible
     defaultControlled: controlled.value,
     neverRequired: false,
     preprocessRaw(
@@ -232,6 +237,7 @@ function decimal(options?: DecimalOptions) {
 // XXX create a way to create arrays with mobx state tree types
 const stringArray = new Converter<string[], IObservableArray<string>>({
   emptyRaw: [],
+  emptyValue: observable.array([]),
   convert(raw) {
     return observable.array(raw);
   },
@@ -318,6 +324,7 @@ function model<M extends IAnyModelType>(model: M) {
   return new Converter<Instance<M> | null, Instance<M>>({
     emptyRaw: null,
     emptyImpossible: true,
+    emptyValue: null as any, // arbitrary as impossible
     defaultControlled: controlled.object,
     neverRequired: false,
     convert(raw) {
@@ -340,6 +347,7 @@ function maybeModel<M, RE, VE>(
   return new Converter({
     emptyRaw: emptyRaw,
     emptyImpossible: false,
+    emptyValue: emptyValue,
     convert: (r: M | RE) => (r !== emptyRaw ? (r as M) : emptyValue),
     render: (v: M | VE) => (v !== emptyValue ? (v as M) : emptyRaw),
     defaultControlled: controlled.object
@@ -348,6 +356,7 @@ function maybeModel<M, RE, VE>(
 
 const object = new Converter<any, any>({
   emptyRaw: null,
+  emptyValue: undefined,
   convert: identity,
   render: identity
 });

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -111,7 +111,6 @@ export class StringConverter<V> extends Converter<string, V> {
 const string = new StringConverter<string>({
   emptyRaw: "",
   emptyValue: "",
-  emptyImpossible: false,
   convert(raw) {
     return raw;
   },
@@ -126,7 +125,6 @@ const string = new StringConverter<string>({
 const number = new StringConverter<number>({
   emptyRaw: "",
   emptyImpossible: true,
-  emptyValue: 1, // arbitrary as impossible
   rawValidate(raw) {
     // deal with case when string starts with .
     if (raw.startsWith(".")) {
@@ -152,7 +150,6 @@ const number = new StringConverter<number>({
 const integer = new StringConverter<number>({
   emptyRaw: "",
   emptyImpossible: true,
-  emptyValue: 1, // arbitrary as impossible
   rawValidate(raw) {
     return INTEGER_REGEX.test(raw);
   },
@@ -170,7 +167,6 @@ const integer = new StringConverter<number>({
 const boolean = new Converter<boolean, boolean>({
   emptyRaw: false,
   emptyImpossible: true,
-  emptyValue: false, // arbitrary as impossible
   convert(raw) {
     return raw;
   },
@@ -205,7 +201,6 @@ function decimal(options?: DecimalOptions) {
   return new StringConverter<string>({
     emptyRaw: "",
     emptyImpossible: true,
-    emptyValue: "", // arbitrary as impossible
     defaultControlled: controlled.value,
     neverRequired: false,
     preprocessRaw(
@@ -324,7 +319,6 @@ function model<M extends IAnyModelType>(model: M) {
   return new Converter<Instance<M> | null, Instance<M>>({
     emptyRaw: null,
     emptyImpossible: true,
-    emptyValue: null as any, // arbitrary as impossible
     defaultControlled: controlled.object,
     neverRequired: false,
     convert(raw) {
@@ -346,7 +340,6 @@ function maybeModel<M, RE, VE>(
 ): IConverter<M | RE, M | VE> {
   return new Converter({
     emptyRaw: emptyRaw,
-    emptyImpossible: false,
     emptyValue: emptyValue,
     convert: (r: M | RE) => (r !== emptyRaw ? (r as M) : emptyValue),
     render: (v: M | VE) => (v !== emptyValue ? (v as M) : emptyRaw),

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -334,39 +334,22 @@ class StringMaybe<V, RE, VE> implements IConverter<string, V | VE> {
   }
 }
 
-class Model<M, RE> implements IConverter<Instance<M> | RE, Instance<M>> {
-  emptyRaw: Instance<M> | RE;
-  emptyImpossible: boolean;
-  defaultControlled: Controlled;
-  neverRequired = false;
-
-  constructor(model: M, emptyRaw: RE) {
-    this.emptyRaw = emptyRaw;
-    this.emptyImpossible = true;
-    this.defaultControlled = controlled.object;
-  }
-  preprocessRaw(raw: Instance<M>): Instance<M> {
-    return raw;
-  }
-
-  async convert(
-    raw: Instance<M> | RE
-  ): Promise<ConversionResponse<Instance<M>>> {
-    if (raw === this.emptyRaw) {
-      return CONVERSION_ERROR;
+function model<M extends IAnyModelType>(model: M) {
+  return new Converter<Instance<M> | null, Instance<M>>({
+    emptyRaw: null,
+    emptyImpossible: true,
+    defaultControlled: controlled.object,
+    neverRequired: false,
+    convert(raw) {
+      if (raw == null) {
+        throw new Error("Raw should never be null at this point");
+      }
+      return raw;
+    },
+    render(value) {
+      return value;
     }
-    return new ConversionValue(raw as Instance<M>);
-  }
-
-  render(value: Instance<M>): Instance<M> {
-    return value;
-  }
-}
-
-function model<M extends IAnyModelType>(
-  model: M
-): IConverter<Instance<M> | null, Instance<M>> {
-  return new Model(model, null);
+  });
 }
 
 function maybeModel<M, RE, VE>(

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,14 +1,13 @@
 import { IObservableArray, observable } from "mobx";
 import { IAnyModelType, Instance } from "mobx-state-tree";
 import {
-  CONVERSION_ERROR,
   ConversionResponse,
   ConversionValue,
   Converter,
   IConverter,
   StateConverterOptionsWithContext
 } from "./converter";
-import { Controlled, controlled } from "./controlled";
+import { controlled } from "./controlled";
 import { identity } from "./utils";
 
 const NUMBER_REGEX = new RegExp("^-?(0|[1-9]\\d*)(\\.\\d*)?$");
@@ -243,9 +242,6 @@ class Decimal implements IConverter<string, string> {
   }
   render(value: string, options: StateConverterOptionsWithContext) {
     return this.converter.render(value, options);
-  }
-  getRaw(value: any) {
-    return value;
   }
 }
 

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -273,6 +273,10 @@ function maybeNull<R, V>(
   return maybeModel(converter, null, null) as IConverter<R | null, V | null>;
 }
 
+// XXX it would be nice if this could be a simple converter instead
+// of a reimplementation. unfortunately the delegation to the
+// underlying converter makes this impossible as it has a different
+// and asynchronous API. We need to refactor this further in the future.
 class StringMaybe<V, RE, VE> implements IConverter<string, V | VE> {
   emptyRaw: string;
   defaultControlled = controlled.value;

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -20,7 +20,7 @@ import { FormAccessor } from "./form-accessor";
 import { currentValidationProps } from "./validation-props";
 import { Accessor } from "./accessor";
 import { ValidateOptions } from "./validate-options";
-import { stat } from "fs";
+import { CONVERSION_ERROR } from "./converter";
 
 export class FieldAccessor<R, V> {
   name: string;
@@ -275,6 +275,16 @@ export class FieldAccessor<R, V> {
     raw = this.field.converter.preprocessRaw(raw, stateConverterOptions);
 
     if (this.field.isRequired(raw, this.required, options)) {
+      if (!this.field.converter.emptyImpossible) {
+        const response = await this.field.converter.convert(
+          this.field.converter.emptyRaw,
+          stateConverterOptions
+        );
+        if (response === CONVERSION_ERROR) {
+          throw new Error("Cannot convert raw value");
+        }
+        this.state.setValueWithoutRawUpdate(this.path, response.value);
+      }
       this.setError(this.requiredError);
       return;
     }

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -256,10 +256,8 @@ export class FieldAccessor<R, V> {
 
   @computed
   get requiredError(): string {
-    if (this.field.requiredError != null) {
-      return errorMessage(this.field.requiredError, this.state.context);
-    }
-    return errorMessage(this.state._requiredError, this.state.context);
+    const requiredError = this.field.requiredError || this.state._requiredError;
+    return errorMessage(requiredError, this.state.context);
   }
 
   @action

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -254,7 +254,13 @@ export class FieldAccessor<R, V> {
     }
 
     // we can still set raw directly before the await
+    const originalRaw = raw;
     this._raw = raw;
+
+    raw = this.field.converter.preprocessRaw(
+      raw,
+      this.state.stateConverterOptionsWithContext || {}
+    );
 
     if (
       this.field.isRequired(
@@ -292,7 +298,7 @@ export class FieldAccessor<R, V> {
     const currentRaw = this._raw;
 
     // if the raw changed in the mean time, bail out
-    if (!comparer.structural(currentRaw, raw)) {
+    if (!comparer.structural(currentRaw, originalRaw)) {
       return;
     }
     // validation only is complete if the currentRaw has been validated

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -276,16 +276,10 @@ export class FieldAccessor<R, V> {
 
     if (this.field.isRequired(raw, this.required, options)) {
       if (!this.field.converter.emptyImpossible) {
-        const response = await this.field.converter.convert(
-          this.field.converter.emptyRaw,
-          stateConverterOptions
+        this.state.setValueWithoutRawUpdate(
+          this.path,
+          this.field.converter.emptyValue
         );
-        if (response === CONVERSION_ERROR) {
-          // we shouldn't get a conversion error as it's possible
-          // to have an empty value
-          throw new Error("Cannot convert empty raw: shouldn't happen");
-        }
-        this.state.setValueWithoutRawUpdate(this.path, response.value);
       }
       this.setError(this.requiredError);
       return;

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -281,7 +281,9 @@ export class FieldAccessor<R, V> {
           stateConverterOptions
         );
         if (response === CONVERSION_ERROR) {
-          throw new Error("Cannot convert raw value");
+          // we shouldn't get a conversion error as it's possible
+          // to have an empty value
+          throw new Error("Cannot convert empty raw: shouldn't happen");
         }
         this.state.setValueWithoutRawUpdate(this.path, response.value);
       }

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -256,6 +256,23 @@ export class FieldAccessor<R, V> {
     // we can still set raw directly before the await
     this._raw = raw;
 
+    if (
+      this.field.isRequired(
+        raw,
+        this.required,
+        options,
+        this.state.stateConverterOptionsWithContext
+      )
+    ) {
+      this.setError(
+        this.field.getRequiredError(
+          this.state.stateConverterOptionsWithContext.context,
+          this.state._requiredError
+        )
+      );
+      return;
+    }
+
     this.setValidating(true);
 
     let processResult;

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -281,10 +281,7 @@ export class FieldAccessor<R, V> {
       // later
       processResult = await this.field.process(
         raw,
-        this.required,
-        this.state.stateConverterOptionsWithContext,
-        this.state._requiredError,
-        options
+        this.state.stateConverterOptionsWithContext
       );
     } catch (e) {
       this.setError("Something went wrong");

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -8,7 +8,13 @@ import {
   comparer,
   IReactionDisposer
 } from "mobx";
-import { Field, ProcessValue, ValidationMessage, ProcessOptions } from "./form";
+import {
+  Field,
+  ProcessValue,
+  ValidationMessage,
+  ProcessOptions,
+  errorMessage
+} from "./form";
 import { FormState } from "./state";
 import { FormAccessor } from "./form-accessor";
 import { currentValidationProps } from "./validation-props";
@@ -248,6 +254,14 @@ export class FieldAccessor<R, V> {
     return this.errorValue === undefined;
   }
 
+  @computed
+  get requiredError(): string {
+    if (this.field.requiredError != null) {
+      return errorMessage(this.field.requiredError, this.state.context);
+    }
+    return errorMessage(this.state._requiredError, this.state.context);
+  }
+
   @action
   async setRaw(raw: R, options?: ProcessOptions) {
     if (this.state.saveStatus === "rightAfter") {
@@ -263,12 +277,7 @@ export class FieldAccessor<R, V> {
     raw = this.field.converter.preprocessRaw(raw, stateConverterOptions);
 
     if (this.field.isRequired(raw, this.required, options)) {
-      this.setError(
-        this.field.getRequiredError(
-          stateConverterOptions.context,
-          this.state._requiredError
-        )
-      );
+      this.setError(this.requiredError);
       return;
     }
 

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -14,6 +14,7 @@ import { FormAccessor } from "./form-accessor";
 import { currentValidationProps } from "./validation-props";
 import { Accessor } from "./accessor";
 import { ValidateOptions } from "./validate-options";
+import { stat } from "fs";
 
 export class FieldAccessor<R, V> {
   name: string;
@@ -257,15 +258,14 @@ export class FieldAccessor<R, V> {
     const originalRaw = raw;
     this._raw = raw;
 
-    raw = this.field.converter.preprocessRaw(
-      raw,
-      this.state.stateConverterOptionsWithContext || {}
-    );
+    const stateConverterOptions = this.state.stateConverterOptionsWithContext;
+
+    raw = this.field.converter.preprocessRaw(raw, stateConverterOptions);
 
     if (this.field.isRequired(raw, this.required, options)) {
       this.setError(
         this.field.getRequiredError(
-          this.state.stateConverterOptionsWithContext.context,
+          stateConverterOptions.context,
           this.state._requiredError
         )
       );
@@ -278,10 +278,7 @@ export class FieldAccessor<R, V> {
     try {
       // XXX is await correct here? we should await the result
       // later
-      processResult = await this.field.process(
-        raw,
-        this.state.stateConverterOptionsWithContext
-      );
+      processResult = await this.field.process(raw, stateConverterOptions);
     } catch (e) {
       this.setError("Something went wrong");
       this.setValidating(false);

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -262,14 +262,7 @@ export class FieldAccessor<R, V> {
       this.state.stateConverterOptionsWithContext || {}
     );
 
-    if (
-      this.field.isRequired(
-        raw,
-        this.required,
-        options,
-        this.state.stateConverterOptionsWithContext
-      )
-    ) {
+    if (this.field.isRequired(raw, this.required, options)) {
       this.setError(
         this.field.getRequiredError(
           this.state.stateConverterOptionsWithContext.context,

--- a/src/form.ts
+++ b/src/form.ts
@@ -203,12 +203,6 @@ export class Field<R, V> {
     return errorMessage(this.conversionError, context);
   }
 
-  isRequiredIgnored(options: ProcessOptions | undefined): boolean {
-    const ignoreRequired: boolean =
-      options != null ? !!options.ignoreRequired : false;
-    return this.converter.neverRequired || ignoreRequired;
-  }
-
   isRequired(
     raw: R,
     required: boolean,
@@ -220,7 +214,9 @@ export class Field<R, V> {
     if (!this.converter.neverRequired && this.converter.emptyImpossible) {
       return true;
     }
-    if (this.isRequiredIgnored(options)) {
+    const ignoreRequired: boolean =
+      options != null ? !!options.ignoreRequired : false;
+    if (this.converter.neverRequired || ignoreRequired) {
       return false;
     }
     return required;

--- a/src/form.ts
+++ b/src/form.ts
@@ -226,6 +226,20 @@ export class Field<R, V> {
     return this.conversionError(context);
   }
 
+  isRequiredAndMissing(
+    raw: R,
+    required: boolean,
+    options?: ProcessOptions
+  ): boolean {
+    const ignoreRequired = options != null ? options.ignoreRequired : false;
+    return (
+      !this.converter.neverRequired &&
+      !ignoreRequired &&
+      raw === this.converter.emptyRaw &&
+      required
+    );
+  }
+
   async process(
     raw: R,
     required: boolean,
@@ -234,13 +248,8 @@ export class Field<R, V> {
     options?: ProcessOptions
   ): Promise<ProcessResponse<V>> {
     raw = this.converter.preprocessRaw(raw, stateConverterOptions);
-    const ignoreRequired = options != null ? options.ignoreRequired : false;
-    if (
-      !this.converter.neverRequired &&
-      !ignoreRequired &&
-      raw === this.converter.emptyRaw &&
-      required
-    ) {
+
+    if (this.isRequiredAndMissing(raw, required, options)) {
       return new ValidationMessage(
         this.getRequiredError(stateConverterOptions.context, stateRequiredError)
       );

--- a/src/form.ts
+++ b/src/form.ts
@@ -247,8 +247,7 @@ export class Field<R, V> {
   isRequired(
     raw: R,
     required: boolean,
-    options: ProcessOptions | undefined,
-    stateConverterOptions: StateConverterOptionsWithContext | undefined
+    options: ProcessOptions | undefined
   ): boolean {
     return (
       !this.isRequiredIgnored(options) &&

--- a/src/form.ts
+++ b/src/form.ts
@@ -226,18 +226,6 @@ export class Field<R, V> {
     return this.conversionError(context);
   }
 
-  isRequiredAndMissing(raw: R, required: boolean): boolean {
-    return raw === this.converter.emptyRaw && required;
-  }
-
-  isImpossibleEmpty(raw: R): boolean {
-    return (
-      raw === this.converter.emptyRaw &&
-      !this.converter.neverRequired &&
-      this.converter.emptyImpossible
-    );
-  }
-
   isRequiredIgnored(options: ProcessOptions | undefined): boolean {
     const ignoreRequired: boolean =
       options != null ? !!options.ignoreRequired : false;
@@ -249,10 +237,13 @@ export class Field<R, V> {
     required: boolean,
     options: ProcessOptions | undefined
   ): boolean {
-    return (
-      !this.isRequiredIgnored(options) &&
-      (this.isRequiredAndMissing(raw, required) || this.isImpossibleEmpty(raw))
-    );
+    if (this.isRequiredIgnored(options)) {
+      return false;
+    }
+    if (raw !== this.converter.emptyRaw) {
+      return false;
+    }
+    return required || this.converter.emptyImpossible;
   }
 
   async process(

--- a/src/form.ts
+++ b/src/form.ts
@@ -134,16 +134,6 @@ export interface ProcessOptions {
   ignoreRequired?: boolean;
 }
 
-function getRequiredError(
-  context: any,
-  requiredError: string | ErrorFunc
-): string {
-  if (typeof requiredError === "string") {
-    return requiredError;
-  }
-  return requiredError(context);
-}
-
 export class Field<R, V> {
   rawValidators: Validator<R>[];
   validators: Validator<V>[];
@@ -209,21 +199,8 @@ export class Field<R, V> {
     throw new Error("This is a function to enable type introspection");
   }
 
-  getRequiredError(
-    context: any,
-    stateRequiredError: string | ErrorFunc
-  ): string {
-    if (this.requiredError != null) {
-      return getRequiredError(context, this.requiredError);
-    }
-    return getRequiredError(context, stateRequiredError);
-  }
-
   getConversionError(context: any): string {
-    if (typeof this.conversionError === "string") {
-      return this.conversionError;
-    }
-    return this.conversionError(context);
+    return errorMessage(this.conversionError, context);
   }
 
   isRequiredIgnored(options: ProcessOptions | undefined): boolean {
@@ -296,4 +273,11 @@ export interface GroupOptions<D extends FormDefinition<any>> {
 
 export class Group<D extends FormDefinition<any>> {
   constructor(public options: GroupOptions<D>) {}
+}
+
+export function errorMessage(message: string | ErrorFunc, context: any) {
+  if (typeof message === "string") {
+    return message;
+  }
+  return message(context);
 }

--- a/src/form.ts
+++ b/src/form.ts
@@ -244,6 +244,13 @@ export class Field<R, V> {
     return this.converter.neverRequired || ignoreRequired;
   }
 
+  isRequired(raw: R, required: boolean, options?: ProcessOptions): boolean {
+    return (
+      !this.isRequiredIgnored(options) &&
+      (this.isRequiredAndMissing(raw, required) || this.isImpossibleEmpty(raw))
+    );
+  }
+
   async process(
     raw: R,
     required: boolean,
@@ -253,10 +260,7 @@ export class Field<R, V> {
   ): Promise<ProcessResponse<V>> {
     raw = this.converter.preprocessRaw(raw, stateConverterOptions);
 
-    if (
-      !this.isRequiredIgnored(options) &&
-      (this.isRequiredAndMissing(raw, required) || this.isImpossibleEmpty(raw))
-    ) {
+    if (this.isRequired(raw, required, options)) {
       return new ValidationMessage(
         this.getRequiredError(stateConverterOptions.context, stateRequiredError)
       );

--- a/src/form.ts
+++ b/src/form.ts
@@ -250,8 +250,6 @@ export class Field<R, V> {
     options: ProcessOptions | undefined,
     stateConverterOptions: StateConverterOptionsWithContext | undefined
   ): boolean {
-    raw = this.converter.preprocessRaw(raw, stateConverterOptions || {});
-
     return (
       !this.isRequiredIgnored(options) &&
       (this.isRequiredAndMissing(raw, required) || this.isImpossibleEmpty(raw))
@@ -262,8 +260,6 @@ export class Field<R, V> {
     raw: R,
     stateConverterOptions: StateConverterOptionsWithContext
   ): Promise<ProcessResponse<V>> {
-    raw = this.converter.preprocessRaw(raw, stateConverterOptions);
-
     for (const validator of this.rawValidators) {
       const validationResponse = await validator(
         raw,

--- a/src/form.ts
+++ b/src/form.ts
@@ -214,13 +214,16 @@ export class Field<R, V> {
     required: boolean,
     options: ProcessOptions | undefined
   ): boolean {
-    if (this.isRequiredIgnored(options)) {
-      return false;
-    }
     if (raw !== this.converter.emptyRaw) {
       return false;
     }
-    return required || this.converter.emptyImpossible;
+    if (!this.converter.neverRequired && this.converter.emptyImpossible) {
+      return true;
+    }
+    if (this.isRequiredIgnored(options)) {
+      return false;
+    }
+    return required;
   }
 
   async process(

--- a/src/form.ts
+++ b/src/form.ts
@@ -238,13 +238,20 @@ export class Field<R, V> {
     );
   }
 
-  isRequiredIgnored(options?: ProcessOptions): boolean {
+  isRequiredIgnored(options: ProcessOptions | undefined): boolean {
     const ignoreRequired: boolean =
       options != null ? !!options.ignoreRequired : false;
     return this.converter.neverRequired || ignoreRequired;
   }
 
-  isRequired(raw: R, required: boolean, options?: ProcessOptions): boolean {
+  isRequired(
+    raw: R,
+    required: boolean,
+    options: ProcessOptions | undefined,
+    stateConverterOptions: StateConverterOptionsWithContext | undefined
+  ): boolean {
+    raw = this.converter.preprocessRaw(raw, stateConverterOptions || {});
+
     return (
       !this.isRequiredIgnored(options) &&
       (this.isRequiredAndMissing(raw, required) || this.isImpossibleEmpty(raw))
@@ -259,12 +266,6 @@ export class Field<R, V> {
     options?: ProcessOptions
   ): Promise<ProcessResponse<V>> {
     raw = this.converter.preprocessRaw(raw, stateConverterOptions);
-
-    if (this.isRequired(raw, required, options)) {
-      return new ValidationMessage(
-        this.getRequiredError(stateConverterOptions.context, stateRequiredError)
-      );
-    }
 
     for (const validator of this.rawValidators) {
       const validationResponse = await validator(

--- a/src/form.ts
+++ b/src/form.ts
@@ -260,10 +260,7 @@ export class Field<R, V> {
 
   async process(
     raw: R,
-    required: boolean,
-    stateConverterOptions: StateConverterOptionsWithContext,
-    stateRequiredError: string | ErrorFunc,
-    options?: ProcessOptions
+    stateConverterOptions: StateConverterOptionsWithContext
   ): Promise<ProcessResponse<V>> {
     raw = this.converter.preprocessRaw(raw, stateConverterOptions);
 

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -8,7 +8,6 @@ import {
   converters,
   Converter
 } from "../src";
-import { type } from "os";
 
 // "always" leads to trouble during initialization.
 configure({ enforceActions: "observed" });
@@ -132,7 +131,6 @@ test("context in converter", async () => {
 
   const myConverter = new Converter<string, string>({
     emptyRaw: "",
-    emptyValue: "",
     rawValidate(raw, options) {
       return raw.startsWith(options.context.prefix);
     },
@@ -169,7 +167,6 @@ test("context in converter in convert", async () => {
 
   const myConverter = new Converter<string, string>({
     emptyRaw: "",
-    emptyValue: "",
     convert(raw: string, options) {
       return options.context.prefix + raw;
     },
@@ -200,7 +197,6 @@ test("context in converter in render", async () => {
 
   const myConverter = new Converter<string, string>({
     emptyRaw: "",
-    emptyValue: "",
     convert(raw: string) {
       return raw;
     },

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -132,6 +132,7 @@ test("context in converter", async () => {
 
   const myConverter = new Converter<string, string>({
     emptyRaw: "",
+    emptyValue: "",
     rawValidate(raw, options) {
       return raw.startsWith(options.context.prefix);
     },
@@ -168,6 +169,7 @@ test("context in converter in convert", async () => {
 
   const myConverter = new Converter<string, string>({
     emptyRaw: "",
+    emptyValue: "",
     convert(raw: string, options) {
       return options.context.prefix + raw;
     },
@@ -198,6 +200,7 @@ test("context in converter in render", async () => {
 
   const myConverter = new Converter<string, string>({
     emptyRaw: "",
+    emptyValue: "",
     convert(raw: string) {
       return raw;
     },

--- a/test/converter.test.ts
+++ b/test/converter.test.ts
@@ -8,6 +8,7 @@ configure({ enforceActions: "observed" });
 test("simple converter", async () => {
   const converter = new Converter<string, string>({
     emptyRaw: "",
+    emptyValue: "",
     convert: raw => raw,
     render: value => value
   });
@@ -25,6 +26,8 @@ test("simple converter", async () => {
 test("converter to integer", async () => {
   const converter = new Converter<string, number>({
     emptyRaw: "",
+    emptyImpossible: true,
+    emptyValue: 1,
     rawValidate: raw => /^\d+$/.test(raw),
     convert: raw => parseInt(raw, 10),
     render: value => value.toString()
@@ -41,6 +44,8 @@ test("converter to integer", async () => {
 test("converter with validate", async () => {
   const converter = new Converter<string, number>({
     emptyRaw: "",
+    emptyImpossible: true,
+    emptyValue: 1,
     convert: raw => parseInt(raw, 10),
     render: value => value.toString(),
     validate: value => value <= 10
@@ -59,6 +64,7 @@ test("converter with async validate", async () => {
 
   const converter = new Converter<string, string>({
     emptyRaw: "",
+    emptyValue: "",
     convert: raw => raw,
     validate: async value => {
       await new Promise(resolve => {

--- a/test/converter.test.ts
+++ b/test/converter.test.ts
@@ -23,11 +23,23 @@ test("simple converter", async () => {
   expect((result2 as ConversionValue<string>).value).toEqual("ConversionError");
 });
 
+test("converter emptyImpossible and emptyValue", async () => {
+  expect(
+    () =>
+      new Converter<string, string>({
+        emptyRaw: "",
+        emptyValue: "",
+        emptyImpossible: true,
+        convert: raw => raw,
+        render: value => value
+      })
+  ).toThrow();
+});
+
 test("converter to integer", async () => {
   const converter = new Converter<string, number>({
     emptyRaw: "",
     emptyImpossible: true,
-    emptyValue: 1,
     rawValidate: raw => /^\d+$/.test(raw),
     convert: raw => parseInt(raw, 10),
     render: value => value.toString()
@@ -45,7 +57,6 @@ test("converter with validate", async () => {
   const converter = new Converter<string, number>({
     emptyRaw: "",
     emptyImpossible: true,
-    emptyValue: 1,
     convert: raw => parseInt(raw, 10),
     render: value => value.toString(),
     validate: value => value <= 10

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -907,8 +907,8 @@ test("FormState can be saved", async () => {
   await field.setRaw("");
 
   // we don't see any client-side validation errors
-  expect(o.foo).toEqual("");
   expect(field.error).toBeUndefined();
+  expect(o.foo).toEqual("");
   // now communicate with the server by doing the save
   const saveResult0 = await state.save();
   expect(saveResult0).toBe(false);

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -473,6 +473,7 @@ test("async validation in converter", async () => {
 
   const converter = new Converter<string, string>({
     emptyRaw: "",
+    emptyValue: "",
     convert: raw => raw,
     validate: async value => {
       await new Promise(resolve => {

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -894,7 +894,7 @@ test("FormState can be saved", async () => {
 
   async function save(data: any) {
     if (data.foo === "") {
-      return { foo: "Required" };
+      return { foo: "Wrong" };
     }
     return null;
   }
@@ -912,7 +912,7 @@ test("FormState can be saved", async () => {
   // now communicate with the server by doing the save
   const saveResult0 = await state.save();
   expect(saveResult0).toBe(false);
-  expect(field.error).toEqual("Required");
+  expect(field.error).toEqual("Wrong");
 
   // correct things
   await field.setRaw("BAR");

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1225,8 +1225,11 @@ test("required with string", async () => {
 
   const field = state.field("foo");
 
+  expect(field.value).toEqual("FOO");
+
   await field.setRaw("");
   expect(field.error).toEqual("Required");
+  expect(field.value).toEqual("");
 });
 
 test("required with string and whitespace", async () => {
@@ -1320,7 +1323,7 @@ test("required with maybe", async () => {
   expect(field.value).toEqual(3);
   await field.setRaw("");
   expect(field.error).toEqual("Required");
-  expect(field.value).toEqual(3);
+  expect(field.value).toBeUndefined();
 });
 
 test("required with maybeNull", async () => {
@@ -1347,7 +1350,7 @@ test("required with maybeNull", async () => {
   expect(field.value).toEqual(3);
   await field.setRaw("");
   expect(field.error).toEqual("Required");
-  expect(field.value).toEqual(3);
+  expect(field.value).toBeNull();
 });
 
 test("setting value on model will update form", async () => {

--- a/test/ignore.test.ts
+++ b/test/ignore.test.ts
@@ -29,6 +29,32 @@ test("setRaw with required ignore", async () => {
   expect(o.foo).toEqual("");
 });
 
+test("setRaw with required ignore with automatically required", async () => {
+  const M = types.model("M", {
+    foo: types.number
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.number)
+  });
+
+  const o = M.create({ foo: 1 });
+
+  const state = form.state(o);
+  const field = state.field("foo");
+
+  await field.setRaw("");
+  expect(field.error).toEqual("Required");
+  expect(field.value).toEqual(1);
+
+  // we can set ignoreRequired, but it has no impact
+  // if the field *has* to be required by definition
+  await field.setRaw("", { ignoreRequired: true });
+  expect(field.error).toEqual("Required");
+  expect(field.value).toEqual(1);
+  expect(o.foo).toEqual(1);
+});
+
 test("FormState can be saved ignoring required", async () => {
   const M = types.model("M", {
     foo: types.string

--- a/test/ignore.test.ts
+++ b/test/ignore.test.ts
@@ -22,9 +22,11 @@ test("setRaw with required ignore", async () => {
   const field = state.field("foo");
 
   await field.setRaw("");
-  expect(field.value).toEqual("FOO");
+  expect(field.error).toEqual("Required");
+  expect(field.value).toEqual("");
 
   await field.setRaw("", { ignoreRequired: true });
+  expect(field.error).toBeUndefined();
   expect(field.value).toEqual("");
   expect(o.foo).toEqual("");
 });
@@ -80,11 +82,13 @@ test("FormState can be saved ignoring required", async () => {
   // we set the raw to the empty string even though it's required
   await field.setRaw("");
   expect(field.error).toEqual("Required");
-  expect(o.foo).toEqual("FOO");
+  expect(o.foo).toEqual("");
 
   // now we save, ignoring required
   const saveResult = await state.save({ ignoreRequired: true });
   // we still see the message, even though save succeeded
+  // XXX is this really the desired behavior? don't we want
+  // the required error until we save without ignoreRequired?
   expect(field.error).toEqual("Required");
   // but saving actually succeeded
   expect(o.foo).toEqual("");


### PR DESCRIPTION
When we set a required field and it allows an empty value, set it even though we display an error message as well.

Extensive refactoring to separate the whole required story from the process logic to make this easier to do. Introduced the notion of an "emptyValue" or "emptyImpossible" for converters -- you can either supply the underlying empty value or say there is no empty value possible.
