### PR TITLE
Fix thousand separators being added wrongly after decimal separators.

### DIFF
--- a/src/converters.ts
+++ b/src/converters.ts
@@ -78,7 +78,13 @@ function renderThousandSeparators(
   if (options.thousandSeparator == null || !options.renderThousands) {
     return value;
   }
-  return value.replace(/\B(?=(\d{3})+(?!\d))/g, options.thousandSeparator);
+  const decimalSeparator = options.decimalSeparator || ".";
+  const splitValue = value.split(decimalSeparator);
+  splitValue[0] = splitValue[0].replace(
+    /\B(?=(\d{3})+(?!\d))/g,
+    options.thousandSeparator
+  );
+  return splitValue.join(decimalSeparator);
 }
 
 function convertSeparators(

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -218,6 +218,23 @@ test("decimal converter render with six decimals", async () => {
   expect(rendered).toEqual("4,000000");
 });
 
+test("decimal converter render with six decimals and thousand separators", async () => {
+  const converter = converters.decimal({ decimalPlaces: 6 });
+  const options = {
+    decimalSeparator: ",",
+    thousandSeparator: ".",
+    renderThousands: true
+  };
+  const value = "4000000.000000";
+  const processedValue = converter.preprocessRaw(value, options);
+  const converted = await converter.convert(processedValue, options);
+  const rendered = await converter.render(
+    (converted as ConversionValue<any>).value,
+    options
+  );
+  expect(rendered).toEqual("4.000.000,000000");
+});
+
 test("decimal converter render, six decimals, no decimalSeparator", async () => {
   const converter = converters.decimal({ decimalPlaces: 6 });
   const options = {

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -63,6 +63,10 @@ test("number converter", async () => {
   await checkWithOptions(converters.number, "4.314.314", 4314314, {
     thousandSeparator: "."
   });
+  await checkWithOptions(converters.number, "4.000,000000", 4000, {
+    decimalSeparator: ",",
+    thousandSeparator: "."
+  });
   await fails(converters.number, "foo");
   await fails(converters.number, "1foo");
   await fails(converters.number, "");
@@ -123,6 +127,15 @@ test("decimal converter", async () => {
   await checkWithOptions(converters.decimal({}), "4.314.314", "4314314", {
     thousandSeparator: "."
   });
+  await checkWithOptions(
+    converters.decimal({ decimalPlaces: 6 }),
+    "4.000,000000",
+    "4000.000000",
+    {
+      decimalSeparator: ",",
+      thousandSeparator: "."
+    }
+  );
   await checkWithOptions(
     converters.decimal({ decimalPlaces: 2 }),
     "36.365,21",
@@ -186,6 +199,39 @@ test("decimal converter render with renderThousands false", async () => {
     options
   );
   expect(rendered).toEqual("4314314,31");
+});
+
+test("decimal converter render with six decimals", async () => {
+  const converter = converters.decimal({ decimalPlaces: 6 });
+  const options = {
+    decimalSeparator: ",",
+    thousandSeparator: ".",
+    renderThousands: true
+  };
+  const value = "4.000000";
+  const processedValue = converter.preprocessRaw(value, options);
+  const converted = await converter.convert(processedValue, options);
+  const rendered = await converter.render(
+    (converted as ConversionValue<any>).value,
+    options
+  );
+  expect(rendered).toEqual("4,000000");
+});
+
+test("decimal converter render, six decimals, no decimalSeparator", async () => {
+  const converter = converters.decimal({ decimalPlaces: 6 });
+  const options = {
+    thousandSeparator: ".",
+    renderThousands: true
+  };
+  const value = "4.000000";
+  const processedValue = converter.preprocessRaw(value, options);
+  const converted = await converter.convert(processedValue, options);
+  const rendered = await converter.render(
+    (converted as ConversionValue<any>).value,
+    options
+  );
+  expect(rendered).toEqual("4.000000");
 });
 
 test("do not convert a normal string with decimal options", async () => {


### PR DESCRIPTION
Previously, when dealing with decimal places higher than 2, thousand separators would be rendered after the decimal separator. This no longer happens.