### PR TITLE
Derived functionality is bugged when supplied with a context.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.6.2
+
+-   Fixed a bug where render functions were passed a context argument instead of
+    an options argument, with a context inside.
+
 # 1.6.1
 
 -   Set defaultControlled for `textStringArray` converter to `controlled.value`.

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -92,7 +92,12 @@ export class FieldAccessor<R, V> {
         if (derivedValue === undefined) {
           return;
         }
-        this.setRaw(this.field.render(derivedValue, this.state.context));
+        this.setRaw(
+          this.field.render(
+            derivedValue,
+            this.state.stateConverterOptionsWithContext
+          )
+        );
       }
     );
     this._disposer = disposer;
@@ -359,7 +364,10 @@ export class FieldAccessor<R, V> {
     // we don't use setRaw on the field as the value is already
     // correct. setting raw causes addMode for the field
     // to be disabled
-    this._raw = this.field.render(value, this.state.context);
+    this._raw = this.field.render(
+      value,
+      this.state.stateConverterOptionsWithContext
+    );
     // trigger validation
     this.validate();
   }

--- a/src/form.ts
+++ b/src/form.ts
@@ -253,8 +253,8 @@ export class Field<R, V> {
     return new ProcessValue(result.value);
   }
 
-  render(value: V, context: any): R {
-    return this.converter.render(value, context);
+  render(value: V, stateConverterOptions: StateConverterOptionsWithContext): R {
+    return this.converter.render(value, stateConverterOptions);
   }
 }
 

--- a/test/derived.test.ts
+++ b/test/derived.test.ts
@@ -201,3 +201,52 @@ test("calculated repeating push and remove", async () => {
   expect(calculated2.raw).toBe("10");
   expect(touched).toBeTruthy();
 });
+
+test("calculated with context", async () => {
+  const M = types
+    .model("M", {
+      calculated: types.string,
+      a: types.string,
+      b: types.string
+    })
+    .views(self => ({
+      sum() {
+        console.log((parseFloat(self.a) + parseFloat(self.b)).toString());
+        return (parseFloat(self.a) + parseFloat(self.b)).toString();
+      }
+    }));
+
+  function getDecimalPlaces(context: any) {
+    expect(context).not.toBeUndefined();
+    return { decimalPlaces: context.getNumberOfDecimals() };
+  }
+
+  const form = new Form(M, {
+    calculated: new Field(converters.decimal(getDecimalPlaces), {
+      derived: (node: Instance<typeof M>) => node.sum()
+    }),
+    a: new Field(converters.decimal(getDecimalPlaces)),
+    b: new Field(converters.decimal(getDecimalPlaces))
+  });
+
+  const o = M.create({ calculated: "0.0000", a: "1.0000", b: "2.3456" });
+
+  const state = form.state(o, {
+    context: { getNumberOfDecimals: () => 4 }
+  });
+  const calculated = state.field("calculated");
+  const a = state.field("a");
+  const b = state.field("b");
+
+  await resolveReactions();
+  // we show the set value, as no modification was made
+  expect(calculated.raw).toEqual("0.0000");
+  expect(calculated.value).toEqual("0.0000");
+
+  // we now change a, which should modify the derived value
+  await a.setRaw("1.2345");
+  await resolveReactions();
+  expect(calculated.raw).toEqual("3.5801");
+  // and also the underlying value, immediately
+  expect(calculated.value).toEqual("3.5801");
+});

--- a/test/derived.test.ts
+++ b/test/derived.test.ts
@@ -211,7 +211,6 @@ test("calculated with context", async () => {
     })
     .views(self => ({
       sum() {
-        console.log((parseFloat(self.a) + parseFloat(self.b)).toString());
         return (parseFloat(self.a) + parseFloat(self.b)).toString();
       }
     }));


### PR DESCRIPTION
Fixed a bug where render functions were passed a context argument instead of an options argument, with a context inside.