### PR TITLE
Dispose bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+# 1.6.4
+
+-   Fix a bug where you could get strange behavior if you attach a form state to
+    the same MST node multiple times. mstform wasn't properly disposing of its
+    `onPatch` handler and its reactions in use for derived fields. Now mstform
+    automatically cleans up the event handlers of the old form state when you
+    attach a new state to an object with `form.state()`.
+
+    mstform now also exposes a `dispose()` method to `FormState` so you can do
+    this manually.
+
 # 1.6.3
 
 -   Removed decimal trimming when rendering decimals due to buggy behavior.

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -14,7 +14,8 @@ import {
   convertSeparators,
   DecimalOptions,
   getRegex,
-  renderSeparators
+  renderSeparators,
+  trimDecimals
 } from "./decimal";
 
 const NUMBER_REGEX = new RegExp("^-?(0|[1-9]\\d*)(\\.\\d*)?$");
@@ -125,7 +126,10 @@ function decimal(
       return raw;
     },
     render(value, converterOptions) {
-      return renderSeparators(value, converterOptions);
+      return renderSeparators(
+        trimDecimals(value, converterOptions, decimalOptions),
+        converterOptions
+      );
     }
   });
 }

--- a/src/decimal.ts
+++ b/src/decimal.ts
@@ -105,6 +105,27 @@ export function renderSeparators(
   );
 }
 
+export function trimDecimals(
+  value: string,
+  options: StateConverterOptionsWithContext,
+  decimalOptions?:
+    | Partial<DecimalOptions>
+    | ((context: any) => Partial<DecimalOptions>)
+): string {
+  const [before, after] = value.split(".");
+  if (typeof after === "undefined") {
+    return value;
+  }
+  const trimmedAfter = after.substring(
+    0,
+    getOptions(options.context, decimalOptions).decimalPlaces
+  );
+  if (trimmedAfter.length === 0) {
+    return before;
+  }
+  return [before, trimmedAfter].join(".");
+}
+
 export function getOptions(
   context: any,
   options?:

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -52,11 +52,15 @@ export class FieldAccessor<R, V> {
     this._value = state.getValue(this.path);
   }
 
-  clear() {
+  dispose() {
     if (this._disposer == null) {
       return;
     }
     this._disposer();
+  }
+
+  clear() {
+    this.dispose();
   }
 
   @computed
@@ -67,11 +71,6 @@ export class FieldAccessor<R, V> {
   @computed
   get context(): any {
     return this.state.context;
-  }
-
-  @action
-  setDisposer(disposer: IReactionDisposer) {
-    this._disposer = disposer;
   }
 
   createDerivedReaction() {

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -66,6 +66,10 @@ export class FormAccessor<
     return values.every(value => value);
   }
 
+  dispose() {
+    // no op
+  }
+
   clear() {
     // no op
   }

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -25,6 +25,10 @@ export class RepeatingFormAccessor<
     this.name = name;
   }
 
+  dispose() {
+    // no op
+  }
+
   clear() {
     // no op
   }

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -36,6 +36,10 @@ export class RepeatingFormIndexedAccessor<
     );
   }
 
+  dispose() {
+    // no op
+  }
+
   clear() {
     this.formAccessor.flatAccessors.forEach(accessor => {
       accessor.clear();

--- a/src/state.ts
+++ b/src/state.ts
@@ -127,6 +127,8 @@ export class FormState<
   _context: any;
   _converterOptions: StateConverterOptions;
   _requiredError: string | ErrorFunc;
+  // XXX use IDisposer instead
+  _onPatchDisposer: any;
 
   constructor(
     public form: Form<M, D, G>,
@@ -137,7 +139,7 @@ export class FormState<
     this.additionalErrorTree = {};
     this.noRawUpdate = false;
 
-    onPatch(node, patch => {
+    this._onPatchDisposer = onPatch(node, patch => {
       if (patch.op === "remove") {
         this.removePath(patch.path);
       } else if (patch.op === "add") {
@@ -212,6 +214,15 @@ export class FormState<
       checkConverterOptions(this._converterOptions);
       this._requiredError = options.requiredError || "Required";
     }
+  }
+
+  dispose(): void {
+    // clean up onPatch
+    this._onPatchDisposer();
+    // do dispose on all accessors, cleaning up
+    this.formAccessor.flatAccessors.forEach(accessor => {
+      accessor.dispose();
+    });
   }
 
   @computed

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -29,6 +29,10 @@ export class SubFormAccessor<
     );
   }
 
+  dispose() {
+    // no op
+  }
+
   clear() {
     // no op
   }

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -8,6 +8,7 @@ import {
   converters,
   StateConverterOptionsWithContext
 } from "../src";
+import { resolveReactions } from "./utils";
 
 async function check(
   converter: IConverter<any, any>,
@@ -446,15 +447,11 @@ test("text string array converter", async () => {
   expect(field.value).toEqual([]);
 });
 
-function resolveReactions() {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve();
-    }, 0);
-  });
-}
-
-test.only("render decimal number without decimals with decimal separator", async () => {
+test("render decimal number without decimals with decimal separator", async () => {
+  // this exposed a dispose bug that occurred when we had a previous state
+  // and thus two onPatch event handlers. Now we properly dispose of the
+  // previous form state when we attach a new form state to the same
+  // node
   const M = types.model("M", {
     foo: types.string
   });
@@ -481,6 +478,7 @@ test.only("render decimal number without decimals with decimal separator", async
 
   const o = M.create({ foo: "12.3456" });
 
+  // this state is essential to replicate the bug, don't remove!
   const previousState = form.state(o, {
     focus: () => undefined,
     converterOptions: {
@@ -489,9 +487,7 @@ test.only("render decimal number without decimals with decimal separator", async
       renderThousands: true
     },
     context: {
-      getCurrency: () => {
-        currency;
-      }
+      getCurrency: () => currency
     }
   });
   const state = form.state(o, {
@@ -501,9 +497,7 @@ test.only("render decimal number without decimals with decimal separator", async
       renderThousands: true
     },
     context: {
-      getCurrency: () => {
-        currency;
-      }
+      getCurrency: () => currency
     }
   });
   const field = state.field("foo");

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,7 @@
+export function resolveReactions() {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, 0);
+  });
+}


### PR DESCRIPTION
I've introduced a dispose method on the accessors which is now called if you attach a new form state to a node that already has a form state. I've added a test that also tests that this reactions are disposed correctly (they are used with derived values).