### PR TITLE
Stop being dependent on internal mst API and be stricter about types.

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -12,7 +12,8 @@ import {
   FormDefinition,
   ValidationResponse,
   GroupDefinition,
-  ErrorFunc
+  ErrorFunc,
+  IDisposer
 } from "./form";
 import {
   deepCopy,
@@ -127,8 +128,7 @@ export class FormState<
   _context: any;
   _converterOptions: StateConverterOptions;
   _requiredError: string | ErrorFunc;
-  // XXX use IDisposer instead
-  _onPatchDisposer: any;
+  _onPatchDisposer: IDisposer;
 
   constructor(
     public form: Form<M, D, G>,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,3 +61,22 @@ export function deepCopy(o: any): any {
   // we use it for errors which is plain JSON
   return JSON.parse(JSON.stringify(o));
 }
+
+// see discussion on https://github.com/mobxjs/mobx-state-tree/issues/1168
+// I tried declaring the type as  Instance<IAnyModelType> but this
+// resulted in a type any so that wasn't very useful.
+
+let nodeId = 0;
+const nodeMap = new WeakMap<any, number>();
+
+export function getNodeId(node: any): number {
+  // XXX we should have a sanity check to determine whether node is a state tree
+  // node. This requires an update to mobx-state-tree as isModelType has
+  // the wrong signature in the version we depend on
+  let id = nodeMap.get(node);
+  if (id === undefined) {
+    id = nodeId++;
+    nodeMap.set(node, id);
+  }
+  return id;
+}

--- a/test/getNodeId.test.ts
+++ b/test/getNodeId.test.ts
@@ -1,0 +1,24 @@
+import { getNodeId } from "../src/utils";
+import { types } from "mobx-state-tree";
+
+test("getNodeId", () => {
+  const M = types.model("M", {
+    a: types.number
+  });
+  const N = types.model("N", {
+    b: types.string
+  });
+
+  const m1 = M.create({ a: 1 });
+  const m2 = M.create({ a: 2 });
+  const n1 = N.create({ b: "1" });
+
+  const m1Id = getNodeId(m1);
+  const m2Id = getNodeId(m2);
+  const n1Id = getNodeId(n1);
+
+  expect(m1Id).toEqual(getNodeId(m1));
+  expect(m2Id).toEqual(getNodeId(m2));
+  expect(m1Id).not.toEqual(m2Id);
+  expect(m1Id).not.toEqual(n1Id);
+});


### PR DESCRIPTION
After some discussions on the mst issue tracker I modified the code to be independent of MST implementation details.

There is still an issue with detecting that something is a model type instance but that will have to wait until we upgrade the MST dependency.