### PR TITLE
Add disabled, hidden, read-only and inputAllowed properties on every accessor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,11 @@
 
 -   BREAKING: Removed `isRepeatingFormDisabled`. Use the generic `isDisabled`
     version instead.
+-   BREAKING: `isDisabled` now takes any accessor, rather than just a field
+    accessor.
 -   Forms, repeatingForms and subForms can now all be disabled, read-only and
     hidden. They pass these properties to all their children.
--   Form and field accessors now have an inputAllowed property, which returns
+-   Form and field accessors now have an `inputAllowed` property, which returns
     true when an accessor is not disabled, hidden or read-only.
 
 # 1.8.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 -   BREAKING: Removed `isRepeatingFormDisabled`. Use the generic `isDisabled`
     version instead.
--   BREAKING: `isDisabled` now takes any accessor, rather than just a field
-    accessor.
+-   BREAKING: `isDisabled`, `isHidden` and `isReadOnly` now take any accessor,
+    rather than just a field accessor.
 -   Forms, repeatingForms and subForms can now all be disabled, read-only and
     hidden. They pass these properties to all their children.
 -   Form and field accessors now have an `inputAllowed` property, which returns

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.9.0
+
+-   BREAKING: Removed `isRepeatingFormDisabled`. Use the generic `isDisabled`
+    version instead.
+
 # 1.8.0
 
 -   Fieldref support. All accessors expose a 'fieldref' property. This is a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 -   BREAKING: Removed `isRepeatingFormDisabled`. Use the generic `isDisabled`
     version instead.
+-   Forms, repeatingForms and subForms can now all be disabled, read-only and
+    hidden. They pass these properties to all their children.
+-   Form and field accessors now have an inputAllowed property, which returns
+    true when an accessor is not disabled, hidden or read-only.
 
 # 1.8.0
 

--- a/README.md
+++ b/README.md
@@ -981,8 +981,8 @@ To implement hidden behavior, pass in an `isHidden` function.
 To implement readOnly behavior, pass in an `isReadOnly` function.
 
 To implement required behavior, pass in an `isRequired` function. This does not
-only affect the `required` property on the accessor, but also makes the form or
-field require the form or field just as if you used the `required` flag in the
+only affect the `required` property on the accessor, but also makes the field
+require the form or field just as if you used the `required` flag in the field
 definition. The `required` flag in the definition always makes something
 required, no matter what `isRequired` says.
 
@@ -992,12 +992,13 @@ required, no matter what `isRequired` says.
 React input widgets support a `readOnly` prop (HTML input does). There is no
 such behavior for `hidden` or `required`; use `accessor.hidden` and
 `accessor.required` in your rendering code to determine whether a form or field
-wants to be hidden or required. There is also an `inputAllowed` flag on accessors,
-which checks if a form or field isn't disabled, hidden or read-only.
+wants to be hidden, or a field wants to be required. There is also an
+`inputAllowed` flag on accessors, which checks if a form or field isn't disabled,
+hidden or read-only.
 
 When these properties are set on forms, they will automatically be passed down
 to the children of said form. This works for regular forms, repeating forms and
-subforms.
+subforms, and every kind of property except required.
 
 ## Fieldref
 

--- a/README.md
+++ b/README.md
@@ -963,8 +963,8 @@ this.formState = form.state(o, {
 ## Dynamic disabled, hidden, required and readOnly fields
 
 mstform has hooks that let you calculate `hidden`, `disabled`, `required` and
-`readOnly` state based on the field accessor. Here is a small example that
-makes the `foo` field disabled. This uses the JSON Path functionality of
+`readOnly` state based on the accessor. Here is a small example that
+makes the `foo` form or field disabled. This uses the JSON Path functionality of
 mstform to determine whether a field is disabled, but any operation can be
 implemented here. You could for instance retrieve information about which
 fields are disabled dynamically from the backend before you display the form.
@@ -976,26 +976,23 @@ const state = form.state(o, {
 });
 ```
 
-To implement hidden behavior, pass in an `isHidden` function. You can also
-determine whether a repeating form is disabled from add and remove using
-`isRepeatingFormDisabled`. It's up to you to use this information to render the
-add and remove buttons with the disabled status, however.
+To implement hidden behavior, pass in an `isHidden` function.
 
 To implement readOnly behavior, pass in an `isReadOnly` function.
 
 To implement required behavior, pass in an `isRequired` function. This does not
-only affect the `required` property on fieldAccessor, but also makes the field
-require the field just as if you used the `required` flag in the field
-definition. The `required` flag in the field definition always makes something
-required, no wonder what `isRequired` says.
+only affect the `required` property on the accessor, but also makes the form or
+field require the form or field just as if you used the `required` flag in the
+definition. The `required` flag in the definition always makes something
+required, no matter what `isRequired` says.
 
 `isDisabled` returning `true` makes the `disabled` prop `true` in
 `accessor.inputProps`. If `isReadOnly` is true, the `readOnly` flag is added to
 `accessor.inputProps`; otherwise it's absent, but it's up to you to ensure your
 React input widgets support a `readOnly` prop (HTML input does). There is no
 such behavior for `hidden` or `required`; use `accessor.hidden` and
-``accessor.required` in your rendering code to determine whether a field wants
-to be hidden or required.
+``accessor.required` in your rendering code to determine whether a form or field
+wants to be hidden or required.
 
 ## Fieldref
 

--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ required, no matter what `isRequired` says.
 `accessor.inputProps`; otherwise it's absent, but it's up to you to ensure your
 React input widgets support a `readOnly` prop (HTML input does). There is no
 such behavior for `hidden` or `required`; use `accessor.hidden` and
-`accessor.required`in your rendering code to determine whether a form or field
+`accessor.required` in your rendering code to determine whether a form or field
 wants to be hidden or required. There is also an `inputAllowed` flag on accessors,
 which checks if a form or field isn't disabled, hidden or read-only.
 

--- a/README.md
+++ b/README.md
@@ -991,8 +991,13 @@ required, no matter what `isRequired` says.
 `accessor.inputProps`; otherwise it's absent, but it's up to you to ensure your
 React input widgets support a `readOnly` prop (HTML input does). There is no
 such behavior for `hidden` or `required`; use `accessor.hidden` and
-``accessor.required` in your rendering code to determine whether a form or field
-wants to be hidden or required.
+``accessor.required`in your rendering code to determine whether a form or field
+wants to be hidden or required. There is also an`inputAllowed` flag on accessors,
+which checks if a form or field isn't disabled, hidden or read-only.
+
+When these properties are set on forms, they will automatically be passed down
+to the children of said form. This works for regular forms, repeating forms and
+subforms.
 
 ## Fieldref
 

--- a/README.md
+++ b/README.md
@@ -991,8 +991,8 @@ required, no matter what `isRequired` says.
 `accessor.inputProps`; otherwise it's absent, but it's up to you to ensure your
 React input widgets support a `readOnly` prop (HTML input does). There is no
 such behavior for `hidden` or `required`; use `accessor.hidden` and
-``accessor.required`in your rendering code to determine whether a form or field
-wants to be hidden or required. There is also an`inputAllowed` flag on accessors,
+`accessor.required`in your rendering code to determine whether a form or field
+wants to be hidden or required. There is also an `inputAllowed` flag on accessors,
 which checks if a form or field isn't disabled, hidden or read-only.
 
 When these properties are set on forms, they will automatically be passed down

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -240,7 +240,7 @@ export class FieldAccessor<R, V> {
 
   @computed
   get disabled(): boolean {
-    return this.state.isDisabledFunc(this);
+    return this.parent.disabled ? true : this.state.isDisabledFunc(this);
   }
 
   @computed

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -245,12 +245,17 @@ export class FieldAccessor<R, V> {
 
   @computed
   get hidden(): boolean {
-    return this.state.isHiddenFunc(this);
+    return this.parent.hidden ? true : this.state.isHiddenFunc(this);
   }
 
   @computed
   get readOnly(): boolean {
-    return this.state.isReadOnlyFunc(this);
+    return this.parent.readOnly ? true : this.state.isReadOnlyFunc(this);
+  }
+
+  @computed
+  get inputAllowed(): boolean {
+    return !this.disabled && !this.hidden && !this.readOnly;
   }
 
   @computed

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -76,6 +76,21 @@ export class FormAccessor<
   }
 
   @computed
+  get disabled(): boolean {
+    return this.state.isDisabledFunc(this);
+  }
+
+  @computed
+  get hidden(): boolean {
+    return this.state.isHiddenFunc(this);
+  }
+
+  @computed
+  get readOnly(): boolean {
+    return this.state.isReadOnlyFunc(this);
+  }
+
+  @computed
   get path(): string {
     if (this.parent == null) {
       return "";

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -84,12 +84,21 @@ export class FormAccessor<
 
   @computed
   get hidden(): boolean {
-    return this.state.isHiddenFunc(this);
+    return this.parent != null && this.parent.hidden
+      ? true
+      : this.state.isHiddenFunc(this);
   }
 
   @computed
   get readOnly(): boolean {
-    return this.state.isReadOnlyFunc(this);
+    return this.parent != null && this.parent.readOnly
+      ? true
+      : this.state.isReadOnlyFunc(this);
+  }
+
+  @computed
+  get inputAllowed(): boolean {
+    return !this.disabled && !this.hidden && !this.readOnly;
   }
 
   @computed

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -77,7 +77,9 @@ export class FormAccessor<
 
   @computed
   get disabled(): boolean {
-    return this.state.isDisabledFunc(this);
+    return this.parent != null && this.parent.disabled
+      ? true
+      : this.state.isDisabledFunc(this);
   }
 
   @computed

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -109,7 +109,7 @@ export class RepeatingFormAccessor<
 
   @computed
   get disabled(): boolean {
-    return this.state.isDisabledFunc(this);
+    return this.parent.disabled ? true : this.state.isDisabledFunc(this);
   }
 
   @computed

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -114,12 +114,17 @@ export class RepeatingFormAccessor<
 
   @computed
   get hidden(): boolean {
-    return this.state.isHiddenFunc(this);
+    return this.parent.hidden ? true : this.state.isHiddenFunc(this);
   }
 
   @computed
   get readOnly(): boolean {
-    return this.state.isReadOnlyFunc(this);
+    return this.parent.readOnly ? true : this.state.isReadOnlyFunc(this);
+  }
+
+  @computed
+  get inputAllowed(): boolean {
+    return !this.disabled && !this.hidden && !this.readOnly;
   }
 
   @computed

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -109,7 +109,17 @@ export class RepeatingFormAccessor<
 
   @computed
   get disabled(): boolean {
-    return this.state.isRepeatingFormDisabledFunc(this);
+    return this.state.isDisabledFunc(this);
+  }
+
+  @computed
+  get hidden(): boolean {
+    return this.state.isHiddenFunc(this);
+  }
+
+  @computed
+  get readOnly(): boolean {
+    return this.state.isReadOnlyFunc(this);
   }
 
   @computed

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -50,7 +50,7 @@ export class RepeatingFormIndexedAccessor<
 
   @computed
   get disabled(): boolean {
-    return this.state.isDisabledFunc(this);
+    return this.parent.disabled ? true : this.state.isDisabledFunc(this);
   }
 
   @computed

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -55,12 +55,17 @@ export class RepeatingFormIndexedAccessor<
 
   @computed
   get hidden(): boolean {
-    return this.state.isHiddenFunc(this);
+    return this.parent.hidden ? true : this.state.isHiddenFunc(this);
   }
 
   @computed
   get readOnly(): boolean {
-    return this.state.isReadOnlyFunc(this);
+    return this.parent.readOnly ? true : this.state.isReadOnlyFunc(this);
+  }
+
+  @computed
+  get inputAllowed(): boolean {
+    return !this.disabled && !this.hidden && !this.readOnly;
   }
 
   @computed

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -49,6 +49,21 @@ export class RepeatingFormIndexedAccessor<
   }
 
   @computed
+  get disabled(): boolean {
+    return this.state.isDisabledFunc(this);
+  }
+
+  @computed
+  get hidden(): boolean {
+    return this.state.isHiddenFunc(this);
+  }
+
+  @computed
+  get readOnly(): boolean {
+    return this.state.isReadOnlyFunc(this);
+  }
+
+  @computed
   get path(): string {
     return this.parent.path + "/" + this.index;
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,8 +35,8 @@ import {
 } from "./converter";
 import { checkConverterOptions } from "./decimalParser";
 
-export interface FieldAccessorAllows {
-  (fieldAccessor: FieldAccessor<any, any>): boolean;
+export interface AccessorAllows {
+  (accessor: Accessor): boolean;
 }
 
 export interface ErrorOrWarning {
@@ -76,11 +76,10 @@ export interface FormStateOptions<M> {
     afterSave?: ValidationOption;
     pauseDuration?: number;
   };
-  isDisabled?: FieldAccessorAllows;
-  isHidden?: FieldAccessorAllows;
-  isReadOnly?: FieldAccessorAllows;
-  isRepeatingFormDisabled?: RepeatingFormAccessorAllows;
-  isRequired?: FieldAccessorAllows;
+  isDisabled?: AccessorAllows;
+  isHidden?: AccessorAllows;
+  isReadOnly?: AccessorAllows;
+  isRequired?: AccessorAllows;
 
   getError?: ErrorOrWarning;
   getWarning?: ErrorOrWarning;
@@ -113,11 +112,10 @@ export class FormState<
   validationBeforeSave: ValidationOption;
   validationAfterSave: ValidationOption;
   validationPauseDuration: number;
-  isDisabledFunc: FieldAccessorAllows;
-  isHiddenFunc: FieldAccessorAllows;
-  isReadOnlyFunc: FieldAccessorAllows;
-  isRequiredFunc: FieldAccessorAllows;
-  isRepeatingFormDisabledFunc: RepeatingFormAccessorAllows;
+  isDisabledFunc: AccessorAllows;
+  isHiddenFunc: AccessorAllows;
+  isReadOnlyFunc: AccessorAllows;
+  isRequiredFunc: AccessorAllows;
   getErrorFunc: ErrorOrWarning;
   getWarningFunc: ErrorOrWarning;
   extraValidationFunc: ExtraValidation;
@@ -167,7 +165,6 @@ export class FormState<
       this.isHiddenFunc = () => false;
       this.isReadOnlyFunc = () => false;
       this.isRequiredFunc = () => false;
-      this.isRepeatingFormDisabledFunc = () => false;
       this.getErrorFunc = () => undefined;
       this.getWarningFunc = () => undefined;
       this.blurFunc = () => undefined;
@@ -192,9 +189,6 @@ export class FormState<
         : () => false;
       this.isRequiredFunc = options.isRequired
         ? options.isRequired
-        : () => false;
-      this.isRepeatingFormDisabledFunc = options.isRepeatingFormDisabled
-        ? options.isRepeatingFormDisabled
         : () => false;
       this.getErrorFunc = options.getError ? options.getError : () => undefined;
       this.getWarningFunc = options.getWarning

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -50,7 +50,7 @@ export class SubFormAccessor<
 
   @computed
   get disabled(): boolean {
-    return this.state.isDisabledFunc(this);
+    return this.parent.disabled ? true : this.state.isDisabledFunc(this);
   }
 
   @computed

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -49,6 +49,21 @@ export class SubFormAccessor<
   }
 
   @computed
+  get disabled(): boolean {
+    return this.state.isDisabledFunc(this);
+  }
+
+  @computed
+  get hidden(): boolean {
+    return this.state.isHiddenFunc(this);
+  }
+
+  @computed
+  get readOnly(): boolean {
+    return this.state.isReadOnlyFunc(this);
+  }
+
+  @computed
   get path(): string {
     return this.parent.path + "/" + this.name;
   }

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -55,12 +55,17 @@ export class SubFormAccessor<
 
   @computed
   get hidden(): boolean {
-    return this.state.isHiddenFunc(this);
+    return this.parent.hidden ? true : this.state.isHiddenFunc(this);
   }
 
   @computed
   get readOnly(): boolean {
-    return this.state.isReadOnlyFunc(this);
+    return this.parent.readOnly ? true : this.state.isReadOnlyFunc(this);
+  }
+
+  @computed
+  get inputAllowed(): boolean {
+    return !this.disabled && !this.hidden && !this.readOnly;
   }
 
   @computed

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -2858,3 +2858,34 @@ test("setValueAndUpdateRaw", async () => {
   expect(field.raw).toEqual("6.543,21");
   expect(field.value).toEqual("6543.21");
 });
+
+test("repeatingField disabled when repeatingForm disabled", async () => {
+  const N = types.model("N", {
+    repeatingField: types.string
+  });
+
+  const M = types.model("M", {
+    repeating: types.array(N)
+  });
+
+  const form = new Form(M, {
+    repeating: new RepeatingForm({
+      repeatingField: new Field(converters.string)
+    })
+  });
+
+  const o = M.create({
+    repeating: [{ repeatingField: "REPEATING_FIELD" }]
+  });
+
+  const state = form.state(o, {
+    isRepeatingFormDisabled: () => true
+  });
+
+  const repeating = state.repeatingForm("repeating");
+  const repeatingIndex = repeating.index(0);
+  const repeatingField = repeatingIndex.field("repeatingField");
+
+  expect(repeating.disabled).toBeTruthy();
+  expect(repeatingField.disabled).toBeTruthy();
+});

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -2933,7 +2933,7 @@ test("repeatingField disabled when repeatingForm in repeatingForm is disabled", 
   expect(repeatingField.disabled).toBeTruthy();
 });
 
-test("repeatingField disabled when repeatingForm disabled", async () => {
+test("field disabled when form disabled", async () => {
   const M = types.model("M", {
     foo: types.string
   });
@@ -2955,4 +2955,51 @@ test("repeatingField disabled when repeatingForm disabled", async () => {
 
   expect(formAccessor.disabled).toBeTruthy();
   expect(foo.disabled).toBeTruthy();
+});
+
+test("inputAllowed", async () => {
+  const N = types.model("N", {
+    hiddenRepeatingField: types.string
+  });
+
+  const M = types.model("M", {
+    disabledField: types.string,
+    readOnlyField: types.string,
+    repeatingForm: types.array(N)
+  });
+
+  const form = new Form(M, {
+    disabledField: new Field(converters.string),
+    readOnlyField: new Field(converters.string),
+    repeatingForm: new RepeatingForm({
+      hiddenRepeatingField: new Field(converters.string)
+    })
+  });
+
+  const o = M.create({
+    disabledField: "DISABLED",
+    readOnlyField: "READ_ONLY",
+    repeatingForm: [{ hiddenRepeatingField: "HIDDEN_REPEATING_FIELD" }]
+  });
+
+  const state = form.state(o, {
+    isDisabled: accessor => accessor.path === "/disabledField",
+    isHidden: accessor =>
+      accessor.path === "/repeatingForm/0/hiddenRepeatingField",
+    isReadOnly: accessor => accessor.path === "/readOnlyField"
+  });
+
+  const formAccessor = state.formAccessor;
+  const disabledField = state.field("disabledField");
+  const readOnlyField = state.field("readOnlyField");
+  const repeatingForm = state.repeatingForm("repeatingForm");
+  const repeatingIndex = repeatingForm.index(0);
+  const hiddenRepeatingField = repeatingIndex.field("hiddenRepeatingField");
+
+  expect(formAccessor.inputAllowed).toBeTruthy();
+  expect(disabledField.inputAllowed).toBeFalsy();
+  expect(readOnlyField.inputAllowed).toBeFalsy();
+  expect(repeatingForm.inputAllowed).toBeTruthy();
+  expect(repeatingIndex.inputAllowed).toBeTruthy();
+  expect(hiddenRepeatingField.inputAllowed).toBeFalsy();
 });

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -2048,7 +2048,7 @@ test("a form with a repeating disabled field", async () => {
   const repeating = state.repeatingForm("foo");
 
   expect(repeating.disabled).toBeTruthy();
-  expect(repeating.index(0).field("bar").disabled).toBeFalsy();
+  expect(repeating.index(0).field("bar").disabled).toBeTruthy();
 });
 
 test("a form with a hidden field", async () => {
@@ -2889,4 +2889,70 @@ test("repeatingField disabled when repeatingForm disabled", async () => {
   expect(repeating.disabled).toBeTruthy();
   expect(repeatingIndex.disabled).toBeTruthy();
   expect(repeatingField.disabled).toBeTruthy();
+});
+
+test("repeatingField disabled when repeatingForm in repeatingForm is disabled", async () => {
+  const O = types.model("O", {
+    repeatingField: types.string
+  });
+
+  const N = types.model("N", {
+    repeating2: types.array(O)
+  });
+
+  const M = types.model("M", {
+    repeating: types.array(N)
+  });
+
+  const form = new Form(M, {
+    repeating: new RepeatingForm({
+      repeating2: new RepeatingForm({
+        repeatingField: new Field(converters.string)
+      })
+    })
+  });
+
+  const o = M.create({
+    repeating: [{ repeating2: [{ repeatingField: "REPEATING_FIELD" }] }]
+  });
+
+  const state = form.state(o, {
+    isDisabled: accessor => accessor.path === "/repeating"
+  });
+
+  const repeating = state.repeatingForm("repeating");
+  const repeatingIndex = repeating.index(0);
+  const repeating2 = repeatingIndex.repeatingForm("repeating2");
+  const repeating2Index = repeating2.index(0);
+  const repeatingField = repeating2Index.field("repeatingField");
+
+  expect(repeating.disabled).toBeTruthy();
+  expect(repeatingIndex.disabled).toBeTruthy();
+  expect(repeating2.disabled).toBeTruthy();
+  expect(repeating2Index.disabled).toBeTruthy();
+  expect(repeatingField.disabled).toBeTruthy();
+});
+
+test("repeatingField disabled when repeatingForm disabled", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  const o = M.create({
+    foo: "FOO"
+  });
+
+  const state = form.state(o, {
+    isDisabled: accessor => accessor.path === ""
+  });
+
+  const formAccessor = state.formAccessor;
+  const foo = state.field("foo");
+
+  expect(formAccessor.disabled).toBeTruthy();
+  expect(foo.disabled).toBeTruthy();
 });

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -2879,7 +2879,7 @@ test("repeatingField disabled when repeatingForm disabled", async () => {
   });
 
   const state = form.state(o, {
-    isRepeatingFormDisabled: () => true
+    isDisabled: accessor => accessor.path === "/repeating"
   });
 
   const repeating = state.repeatingForm("repeating");

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -2043,7 +2043,7 @@ test("a form with a repeating disabled field", async () => {
   const o = M.create({ foo: [{ bar: "BAR" }] });
 
   const state = form.state(o, {
-    isRepeatingFormDisabled: accessor => accessor.path === "/foo"
+    isDisabled: accessor => accessor.path === "/foo"
   });
   const repeating = state.repeatingForm("foo");
 
@@ -2887,5 +2887,6 @@ test("repeatingField disabled when repeatingForm disabled", async () => {
   const repeatingField = repeatingIndex.field("repeatingField");
 
   expect(repeating.disabled).toBeTruthy();
+  expect(repeatingIndex.disabled).toBeTruthy();
   expect(repeatingField.disabled).toBeTruthy();
 });

--- a/test/subform.test.ts
+++ b/test/subform.test.ts
@@ -71,3 +71,74 @@ test("sub form validation", async () => {
 
   expect(state.isValid).toBeTruthy();
 });
+
+test("SubField disabled when SubForm disabled", async () => {
+  const N = types.model("N", {
+    subField: types.string
+  });
+
+  const M = types.model("M", {
+    subForm: N
+  });
+
+  const form = new Form(M, {
+    subForm: new SubForm({
+      subField: new Field(converters.string)
+    })
+  });
+
+  const o = M.create({
+    subForm: { subField: "SUB_FIELD" }
+  });
+
+  const state = form.state(o, {
+    isDisabled: accessor => accessor.path === "/subForm"
+  });
+
+  const subForm = state.subForm("subForm");
+  const subField = state.subForm("subForm").field("subField");
+
+  expect(subForm.disabled).toBeTruthy();
+  expect(subField.disabled).toBeTruthy();
+});
+
+test("SubField disabled when SubForm in a SubForm is disabled", async () => {
+  const O = types.model("O", {
+    subField: types.string
+  });
+
+  const N = types.model("N", {
+    subForm2: O
+  });
+
+  const M = types.model("M", {
+    subForm: N
+  });
+
+  const form = new Form(M, {
+    subForm: new SubForm({
+      subForm2: new SubForm({
+        subField: new Field(converters.string)
+      })
+    })
+  });
+
+  const o = M.create({
+    subForm: { subForm2: { subField: "SUB_FIELD" } }
+  });
+
+  const state = form.state(o, {
+    isDisabled: accessor => accessor.path === "/subForm"
+  });
+
+  const subForm = state.subForm("subForm");
+  const subForm2 = state.subForm("subForm").subForm("subForm2");
+  const subField = state
+    .subForm("subForm")
+    .subForm("subForm2")
+    .field("subField");
+
+  expect(subForm.disabled).toBeTruthy();
+  expect(subForm2.disabled).toBeTruthy();
+  expect(subField.disabled).toBeTruthy();
+});


### PR DESCRIPTION
-   BREAKING: Removed `isRepeatingFormDisabled`. Use the generic `isDisabled`
    version instead.
-   Forms, repeatingForms and subForms can now all be disabled, read-only and
    hidden. They pass these properties to all their children.
-   Form and field accessors now have an inputAllowed property, which returns
    true when an accessor is not disabled, hidden or read-only.