### PR TITLE
Dynamic converters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,35 @@
+# 1.10.0
+
+-   BREAKING CHANGE: the decimal converter accepts options, like this:
+
+    `converters.decimal({allowNegative: false})`
+
+    Previously it was also possible to pass a function into the `decimal`
+    converter which would return options, like this:
+
+    `converters.decimal(getOptions)`.
+
+    This was a way to make options dynamic and depend on context. You can't do
+    this anymore, but instead this system has been generalized with
+    `converters.dynamic`.
+
+    `converters.decimal(getOptions)` becomes
+    `converters.dynamic(converters.decimal, getOptions)`
+
+    A `converters.maybe(converters.decimal(getOptions))` becomes
+    `converters.maybe(converters.dynamic(converters.decimal, getOptions))`, and
+    the same for `maybeNull`.
+
+    `getOptions` gets two parameters: `context` (as passed to `state()`) and a
+    new second parameter, `accessor`, the field accessor for which this
+    converter is working.
+
+    While `converters.dynamic` currently only works for decimal, it will work
+    for new converters to be introduced as well that take parameters.
+
+-   Some internal reworking to prepare for versions of the existing converters
+    that take parameters.
+
 # 1.9.0
 
 -   BREAKING: Removed `isRepeatingFormDisabled`. Use the generic `isDisabled`

--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ have some properties in common:
 
 -   `path`: The JSON path to the underlying MST value (see mobx-state-tree).
 
--   `fieldref`: a generalization of the path to a pattern. `foo/3/bar' becomes`foo[].bar`.
+-   `fieldref`: a generalization of the path to a pattern. `foo/3/bar` becomes
+    `foo[].bar`.
 
 -   `context`: The context object such as passed into `form.state()`.
 
@@ -356,8 +357,8 @@ other object:
     maximum `maxWholeDigits` (default 10) before the period and a maximum of
     `decimalPlaces` (default 2) after the period. `decimalPlaces` also controls
     the number of decimals that is initially rendered when opening the form.
-    With `allowNegative` (boolean, default true) you can specify if negatives
-    are allowed.
+    With `allowNegative` (boolean, default true) you can specify if negative
+    values are allowed.
 
 Number and decimal converters also respond to a handful of options through the
 use of `converterOptions`. `decimalSeparator` specifies the character used to

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ have some properties in common:
 
 -   `path`: The JSON path to the underlying MST value (see mobx-state-tree).
 
+-   `fieldref`: a generalization of the path to a pattern. `foo/3/bar' becomes`foo[].bar`.
+
 -   `context`: The context object such as passed into `form.state()`.
 
 -   `isValid`: Is true if the accessor (and all its sub-accessors) is valid.
@@ -355,9 +357,7 @@ other object:
     `decimalPlaces` (default 2) after the period. `decimalPlaces` also controls
     the number of decimals that is initially rendered when opening the form.
     With `allowNegative` (boolean, default true) you can specify if negatives
-    are allowed. These options can be set directly, or through the use of a
-    function that returns these options based on `context`. Using a function
-    allows these options to be dynamic.
+    are allowed.
 
 Number and decimal converters also respond to a handful of options through the
 use of `converterOptions`. `decimalSeparator` specifies the character used to
@@ -382,8 +382,8 @@ instead.
 ### Text Arrays
 
 `converters.textStringArray`: raw value is a string with newlines. Value is an
-array of strings split by newline. You can use this with a textarea to edit an array
-of strings by newline.
+array of strings split by newline. You can use this with a textarea to edit an
+array of strings by newline.
 
 ### Models
 
@@ -407,6 +407,33 @@ empty. This is handy when you have a `types.maybe(types.reference())` in MST.
 
 `converters.maybeNull(converter)` is like `converters.maybe` but is designed to
 work with `types.maybeNull`, so the empty value is `null`.
+
+### Dynamic
+
+`converters.dynamic(converter, getOptions)`. This works on any converter that
+expects a parameter object for its configuration. Currently this is only
+`converters.decimal`.
+
+This is a way to make the parameters for a converter dynamic and get
+decided at run-time, based on the `context` you pass into `state()`
+as well as the field accessor -- these get passed into the `getOptions`
+function as arguments. So:
+
+```js
+const form = new Form(Foo, {
+    value: new Field(
+        converters.dynamic(converters.decimal, (context, accessor) => {
+            return { allowNegative: context.weWantNegatives };
+        })
+    )
+});
+```
+
+allows negative values for this decimal dynamically if
+`context.weWantNegatives` is set to `true`.
+
+`converters.maybe` and `converters.maybeNull` wrap around `converters.dynamic`,
+so it's `converters.maybe(converters.dynamic(converters.decimal, getOptions))`.
 
 ### Object
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
         "tslint": "^5.8.0",
         "tslint-config-prettier": "^1.1.0",
         "tslint-config-standard": "^7.0.0",
-        "typescript": "3",
+        "typescript": "3.4.1",
         "validate-commit-msg": "^2.12.2",
         "webpack": "^4.16.2",
         "webpack-cli": "^3.1.0",

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -146,10 +146,3 @@ export function withDefaults<O, R, V>(
     return converterFactory({ ...defaults, ...partialOptions });
   };
 }
-
-export function instanceWithDefaults<O, R, V>(
-  converterFactory: ConverterFactory<O, R, V>,
-  defaults: O
-): IConverter<R, V> {
-  return converterFactory({ ...defaults });
-}

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -127,3 +127,18 @@ export class Converter<R, V> implements IConverter<R, V> {
     return this.definition.render(value, options);
   }
 }
+
+export interface PartialConverterFactory<O, R, V> {
+  (options?: Partial<O>): IConverter<R, V>;
+}
+
+// turn a converter which accepts options into a converter that
+// accepts partial options and fill in the rest with defaults
+export function withDefaults<O, R, V>(
+  converterFactory: (options: O) => IConverter<R, V>,
+  defaults: O
+): PartialConverterFactory<O, R, V> {
+  return (partialOptions?: Partial<O>) => {
+    return converterFactory({ ...defaults, ...partialOptions });
+  };
+}

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -142,3 +142,10 @@ export function withDefaults<O, R, V>(
     return converterFactory({ ...defaults, ...partialOptions });
   };
 }
+
+export function instanceWithDefaults<O, R, V>(
+  converterFactory: (options: O) => IConverter<R, V>,
+  defaults: O
+): IConverter<R, V> {
+  return converterFactory({ ...defaults });
+}

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -132,10 +132,14 @@ export interface PartialConverterFactory<O, R, V> {
   (options?: Partial<O>): IConverter<R, V>;
 }
 
+export interface ConverterFactory<O, R, V> {
+  (options: O): IConverter<R, V>;
+}
+
 // turn a converter which accepts options into a converter that
 // accepts partial options and fill in the rest with defaults
 export function withDefaults<O, R, V>(
-  converterFactory: (options: O) => IConverter<R, V>,
+  converterFactory: ConverterFactory<O, R, V>,
   defaults: O
 ): PartialConverterFactory<O, R, V> {
   return (partialOptions?: Partial<O>) => {
@@ -144,7 +148,7 @@ export function withDefaults<O, R, V>(
 }
 
 export function instanceWithDefaults<O, R, V>(
-  converterFactory: (options: O) => IConverter<R, V>,
+  converterFactory: ConverterFactory<O, R, V>,
   defaults: O
 ): IConverter<R, V> {
   return converterFactory({ ...defaults });

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -9,6 +9,7 @@ export interface StateConverterOptions {
 export interface StateConverterOptionsWithContext
   extends StateConverterOptions {
   context?: any;
+  accessor?: any;
 }
 
 export interface ConverterOptions<R, V> {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,4 +1,5 @@
 import { Controlled, controlled } from "./controlled";
+import { FieldAccessor } from "./field-accessor";
 
 export interface StateConverterOptions {
   decimalSeparator?: string;
@@ -9,7 +10,7 @@ export interface StateConverterOptions {
 export interface StateConverterOptionsWithContext
   extends StateConverterOptions {
   context?: any;
-  accessor?: any;
+  accessor: FieldAccessor<any, any>;
 }
 
 export interface ConverterOptions<R, V> {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -214,8 +214,12 @@ function maybe<M>(
 function maybe<R, V>(
   converter: IConverter<R, V>
 ): IConverter<string, V | undefined> | IConverter<R | null, V | undefined> {
-  if (converter instanceof StringConverter) {
-    return new StringMaybe(converter, undefined);
+  // we detect that we're converting a string, which needs a special maybe
+  if (typeof converter.emptyRaw === "string") {
+    return new StringMaybe(
+      (converter as unknown) as IConverter<string, V>,
+      undefined
+    );
   }
   // XXX add an 'as any' as we get a typeerror for some reason now
   return maybeModel(converter as any, null, undefined) as IConverter<
@@ -233,8 +237,12 @@ function maybeNull<M>(
 function maybeNull<R, V>(
   converter: IConverter<R, V>
 ): IConverter<string, V | null> | IConverter<R | null, V | null> {
-  if (converter instanceof StringConverter) {
-    return new StringMaybe(converter, null);
+  // we detect that we're converting a string, which needs a special maybe
+  if (typeof converter.emptyRaw === "string") {
+    return new StringMaybe(
+      (converter as unknown) as IConverter<string, V>,
+      null
+    );
   }
   // XXX add an 'as any' as we get a typeerror for some reason now
   return maybeModel(converter as any, null, null) as IConverter<

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -7,7 +7,8 @@ import {
   IConverter,
   StateConverterOptionsWithContext,
   ConvertError,
-  withDefaults
+  withDefaults,
+  instanceWithDefaults
 } from "./converter";
 import { controlled } from "./controlled";
 import { dynamic } from "./dynamic-converter";
@@ -28,7 +29,7 @@ export class StringConverter<V> extends Converter<string, V> {
 
 type StringOptions = {};
 
-function stringWithOptions(options?: StringOptions) {
+function string(options: StringOptions) {
   return new StringConverter<string>({
     emptyRaw: "",
     emptyValue: "",
@@ -44,11 +45,9 @@ function stringWithOptions(options?: StringOptions) {
   });
 }
 
-const string = stringWithOptions();
-
 type NumberOptions = {};
 
-function numberWithOptions(options?: NumberOptions) {
+function number(options: NumberOptions) {
   return new StringConverter<number>({
     emptyRaw: "",
     emptyImpossible: true,
@@ -88,11 +87,9 @@ function numberWithOptions(options?: NumberOptions) {
   });
 }
 
-const number = numberWithOptions();
-
 type IntegerOptions = {};
 
-function integerWithOptions(options?: IntegerOptions) {
+function integer(options: IntegerOptions) {
   return new StringConverter<number>({
     emptyRaw: "",
     emptyImpossible: true,
@@ -111,11 +108,9 @@ function integerWithOptions(options?: IntegerOptions) {
   });
 }
 
-const integer = integerWithOptions();
-
 type BooleanOptions = {};
 
-function booleanWithOptions(options?: BooleanOptions) {
+function boolean(options: BooleanOptions) {
   return new Converter<boolean, boolean>({
     emptyRaw: false,
     emptyImpossible: true,
@@ -129,8 +124,6 @@ function booleanWithOptions(options?: BooleanOptions) {
     neverRequired: true
   });
 }
-
-const boolean = booleanWithOptions();
 
 function decimal(options: DecimalOptions) {
   return new StringConverter<string>({
@@ -168,7 +161,7 @@ function decimal(options: DecimalOptions) {
 type StringArrayOptions = {};
 
 // XXX create a way to create arrays with mobx state tree types
-function stringArrayWithOptions(options?: StringArrayOptions) {
+function stringArray(options: StringArrayOptions) {
   return new Converter<string[], IObservableArray<string>>({
     emptyRaw: [],
     emptyValue: observable.array([]),
@@ -181,11 +174,9 @@ function stringArrayWithOptions(options?: StringArrayOptions) {
   });
 }
 
-const stringArray = stringArrayWithOptions();
-
 type TextStringArrayOptions = {};
 
-function textStringArrayWithOptions(options?: TextStringArrayOptions) {
+function textStringArray(options: TextStringArrayOptions) {
   return new Converter<string, IObservableArray<string>>({
     emptyRaw: "",
     emptyValue: observable.array([]),
@@ -202,8 +193,6 @@ function textStringArrayWithOptions(options?: TextStringArrayOptions) {
     }
   });
 }
-
-const textStringArray = textStringArrayWithOptions();
 
 function maybe<R, V>(
   converter: StringConverter<V>
@@ -324,18 +313,18 @@ const object = new Converter<any, any>({
 });
 
 export const converters = {
-  string,
-  number,
-  integer,
+  string: instanceWithDefaults(string, {}),
+  number: instanceWithDefaults(number, {}),
+  integer: instanceWithDefaults(integer, {}),
   decimal: withDefaults(decimal, {
     maxWholeDigits: 10,
     decimalPlaces: 2,
     allowNegative: true,
     addZeroes: true
   }),
-  boolean,
-  textStringArray,
-  stringArray,
+  boolean: instanceWithDefaults(boolean, {}),
+  textStringArray: instanceWithDefaults(textStringArray, {}),
+  stringArray: instanceWithDefaults(stringArray, {}),
   maybe,
   maybeNull,
   model,

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -292,7 +292,7 @@ function model<M extends IAnyModelType>(model: M) {
 }
 
 function maybeModel<M, RE, VE>(
-  converter: IConverter<M | RE, M | VE>,
+  converter: IConverter<M, M>,
   emptyRaw: RE,
   emptyValue: VE
 ): IConverter<M | RE, M | VE> {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -6,16 +6,18 @@ import {
   Converter,
   IConverter,
   StateConverterOptionsWithContext,
-  ConvertError
+  ConvertError,
+  withDefaults
 } from "./converter";
 import { controlled } from "./controlled";
+import { dynamic } from "./dynamic-converter";
+
 import { identity } from "./utils";
 import {
   parseDecimal,
   renderDecimal,
   DecimalOptions,
-  checkConverterOptions,
-  getOptions
+  checkConverterOptions
 } from "./decimalParser";
 
 const INTEGER_REGEX = new RegExp("^-?(0|[1-9]\\d*)$");
@@ -130,11 +132,7 @@ function booleanWithOptions(options?: BooleanOptions) {
 
 const boolean = booleanWithOptions();
 
-function decimal(
-  decimalOptions?:
-    | Partial<DecimalOptions>
-    | ((context: any) => Partial<DecimalOptions>)
-) {
+function decimal(options: DecimalOptions) {
   return new StringConverter<string>({
     emptyRaw: "",
     emptyImpossible: true,
@@ -145,7 +143,6 @@ function decimal(
     },
     convert(raw, converterOptions) {
       checkConverterOptions(converterOptions);
-      const options = getOptions(converterOptions.context, decimalOptions);
       try {
         return parseDecimal(raw, {
           ...options,
@@ -158,8 +155,6 @@ function decimal(
       }
     },
     render(value, converterOptions) {
-      const options = getOptions(converterOptions.context, decimalOptions);
-
       return renderDecimal(value, {
         ...options,
         decimalSeparator: converterOptions.decimalSeparator || ".",
@@ -332,12 +327,18 @@ export const converters = {
   string,
   number,
   integer,
-  decimal,
+  decimal: withDefaults(decimal, {
+    maxWholeDigits: 10,
+    decimalPlaces: 2,
+    allowNegative: true,
+    addZeroes: true
+  }),
   boolean,
   textStringArray,
   stringArray,
   maybe,
   maybeNull,
   model,
-  object
+  object,
+  dynamic
 };

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -24,7 +24,9 @@ export class StringConverter<V> extends Converter<string, V> {
   defaultControlled = controlled.value;
 }
 
-function stringWithOptions() {
+type StringOptions = {};
+
+function stringWithOptions(options?: StringOptions) {
   return new StringConverter<string>({
     emptyRaw: "",
     emptyValue: "",
@@ -42,7 +44,9 @@ function stringWithOptions() {
 
 const string = stringWithOptions();
 
-function numberWithOptions() {
+type NumberOptions = {};
+
+function numberWithOptions(options?: NumberOptions) {
   return new StringConverter<number>({
     emptyRaw: "",
     emptyImpossible: true,
@@ -84,7 +88,9 @@ function numberWithOptions() {
 
 const number = numberWithOptions();
 
-function integerWithOptions() {
+type IntegerOptions = {};
+
+function integerWithOptions(options?: IntegerOptions) {
   return new StringConverter<number>({
     emptyRaw: "",
     emptyImpossible: true,
@@ -105,7 +111,9 @@ function integerWithOptions() {
 
 const integer = integerWithOptions();
 
-function booleanWithOptions() {
+type BooleanOptions = {};
+
+function booleanWithOptions(options?: BooleanOptions) {
   return new Converter<boolean, boolean>({
     emptyRaw: false,
     emptyImpossible: true,
@@ -162,8 +170,10 @@ function decimal(
   });
 }
 
+type StringArrayOptions = {};
+
 // XXX create a way to create arrays with mobx state tree types
-function stringArrayWithOptions() {
+function stringArrayWithOptions(options?: StringArrayOptions) {
   return new Converter<string[], IObservableArray<string>>({
     emptyRaw: [],
     emptyValue: observable.array([]),
@@ -175,9 +185,12 @@ function stringArrayWithOptions() {
     }
   });
 }
+
 const stringArray = stringArrayWithOptions();
 
-function textStringArrayWithOptions() {
+type TextStringArrayOptions = {};
+
+function textStringArrayWithOptions(options?: TextStringArrayOptions) {
   return new Converter<string, IObservableArray<string>>({
     emptyRaw: "",
     emptyValue: observable.array([]),

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -7,8 +7,7 @@ import {
   IConverter,
   StateConverterOptionsWithContext,
   ConvertError,
-  withDefaults,
-  instanceWithDefaults
+  withDefaults
 } from "./converter";
 import { controlled } from "./controlled";
 import { dynamic } from "./dynamic-converter";
@@ -29,7 +28,7 @@ export class StringConverter<V> extends Converter<string, V> {
 
 type StringOptions = {};
 
-function string(options: StringOptions) {
+function stringWithOptions(options?: StringOptions) {
   return new StringConverter<string>({
     emptyRaw: "",
     emptyValue: "",
@@ -45,9 +44,11 @@ function string(options: StringOptions) {
   });
 }
 
+const string = stringWithOptions();
+
 type NumberOptions = {};
 
-function number(options: NumberOptions) {
+function numberWithOptions(options?: NumberOptions) {
   return new StringConverter<number>({
     emptyRaw: "",
     emptyImpossible: true,
@@ -87,9 +88,11 @@ function number(options: NumberOptions) {
   });
 }
 
+const number = numberWithOptions();
+
 type IntegerOptions = {};
 
-function integer(options: IntegerOptions) {
+function integerWithOptions(options?: IntegerOptions) {
   return new StringConverter<number>({
     emptyRaw: "",
     emptyImpossible: true,
@@ -108,9 +111,11 @@ function integer(options: IntegerOptions) {
   });
 }
 
+const integer = integerWithOptions();
+
 type BooleanOptions = {};
 
-function boolean(options: BooleanOptions) {
+function booleanWithOptions(options?: BooleanOptions) {
   return new Converter<boolean, boolean>({
     emptyRaw: false,
     emptyImpossible: true,
@@ -124,6 +129,8 @@ function boolean(options: BooleanOptions) {
     neverRequired: true
   });
 }
+
+const boolean = booleanWithOptions();
 
 function decimal(options: DecimalOptions) {
   return new StringConverter<string>({
@@ -161,7 +168,7 @@ function decimal(options: DecimalOptions) {
 type StringArrayOptions = {};
 
 // XXX create a way to create arrays with mobx state tree types
-function stringArray(options: StringArrayOptions) {
+function stringArrayWithOptions(options?: StringArrayOptions) {
   return new Converter<string[], IObservableArray<string>>({
     emptyRaw: [],
     emptyValue: observable.array([]),
@@ -174,9 +181,11 @@ function stringArray(options: StringArrayOptions) {
   });
 }
 
+const stringArray = stringArrayWithOptions();
+
 type TextStringArrayOptions = {};
 
-function textStringArray(options: TextStringArrayOptions) {
+function textStringArrayWithOptions(options?: TextStringArrayOptions) {
   return new Converter<string, IObservableArray<string>>({
     emptyRaw: "",
     emptyValue: observable.array([]),
@@ -193,6 +202,8 @@ function textStringArray(options: TextStringArrayOptions) {
     }
   });
 }
+
+const textStringArray = textStringArrayWithOptions();
 
 function maybe<R, V>(
   converter: StringConverter<V>
@@ -313,18 +324,18 @@ const object = new Converter<any, any>({
 });
 
 export const converters = {
-  string: instanceWithDefaults(string, {}),
-  number: instanceWithDefaults(number, {}),
-  integer: instanceWithDefaults(integer, {}),
+  string,
+  number,
+  integer,
   decimal: withDefaults(decimal, {
     maxWholeDigits: 10,
     decimalPlaces: 2,
     allowNegative: true,
     addZeroes: true
   }),
-  boolean: instanceWithDefaults(boolean, {}),
-  textStringArray: instanceWithDefaults(textStringArray, {}),
-  stringArray: instanceWithDefaults(stringArray, {}),
+  boolean,
+  textStringArray,
+  stringArray,
   maybe,
   maybeNull,
   model,

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -186,7 +186,8 @@ function maybe<R, V>(
   if (converter instanceof StringConverter) {
     return new StringMaybe(converter, undefined);
   }
-  return maybeModel(converter, null, undefined) as IConverter<
+  // XXX add an 'as any' as we get a typeerror for some reason now
+  return maybeModel(converter as any, null, undefined) as IConverter<
     R | null,
     V | undefined
   >;
@@ -204,7 +205,11 @@ function maybeNull<R, V>(
   if (converter instanceof StringConverter) {
     return new StringMaybe(converter, null);
   }
-  return maybeModel(converter, null, null) as IConverter<R | null, V | null>;
+  // XXX add an 'as any' as we get a typeerror for some reason now
+  return maybeModel(converter as any, null, null) as IConverter<
+    R | null,
+    V | null
+  >;
 }
 
 // XXX it would be nice if this could be a simple converter instead

--- a/src/decimalParser.ts
+++ b/src/decimalParser.ts
@@ -277,36 +277,6 @@ function tokenize(s: string, options: TokenOptions): Token[] | undefined {
   return result;
 }
 
-export function getOptions(
-  context: any,
-  options?:
-    | Partial<DecimalOptions>
-    | ((context: any) => Partial<DecimalOptions>)
-): DecimalOptions {
-  if (typeof options === "function") {
-    return getDecimalOptions(options(context));
-  }
-  if (options == null) {
-    return {
-      maxWholeDigits: 10,
-      decimalPlaces: 2,
-      allowNegative: true,
-      addZeroes: true
-    };
-  }
-  return getDecimalOptions(options);
-}
-
-function getDecimalOptions(options: Partial<DecimalOptions>): DecimalOptions {
-  const maxWholeDigits: number = options.maxWholeDigits || 10;
-  const decimalPlaces: number =
-    options.decimalPlaces == null ? 2 : options.decimalPlaces;
-  const allowNegative: boolean =
-    options.allowNegative == null ? true : options.allowNegative;
-  const addZeroes = !!options.addZeroes;
-  return { maxWholeDigits, decimalPlaces, allowNegative, addZeroes };
-}
-
 export function checkConverterOptions(
   converterOptions: StateConverterOptions | StateConverterOptionsWithContext
 ): void {

--- a/src/dynamic-converter.ts
+++ b/src/dynamic-converter.ts
@@ -1,0 +1,47 @@
+import {
+  IConverter,
+  StateConverterOptionsWithContext,
+  PartialConverterFactory
+} from "./converter";
+
+export interface DynamicOptions<O> {
+  (context: any, accessor: any): Partial<O>;
+}
+
+export interface GetContextConverter<R, V> {
+  (context: any): IConverter<R, V>;
+}
+
+function delegatingConverter<R, V>(
+  defaultConverter: IConverter<R, V>,
+  getContextConverter: GetContextConverter<R, V>
+): IConverter<R, V> {
+  return {
+    emptyRaw: defaultConverter.emptyRaw,
+    emptyValue: defaultConverter.emptyValue,
+    emptyImpossible: defaultConverter.emptyImpossible,
+    defaultControlled: defaultConverter.defaultControlled,
+    neverRequired: defaultConverter.neverRequired,
+    convert(raw: R, options: StateConverterOptionsWithContext) {
+      return getContextConverter(options.context).convert(raw, options);
+    },
+    render(value: V, options: StateConverterOptionsWithContext) {
+      return getContextConverter(options.context).render(value, options);
+    },
+    preprocessRaw(raw: R, options: StateConverterOptionsWithContext) {
+      return getContextConverter(options.context).preprocessRaw(raw, options);
+    }
+  };
+}
+
+export function dynamic<O, R, V>(
+  converterFactory: PartialConverterFactory<O, R, V>,
+  getOptions: DynamicOptions<O>
+): IConverter<R, V> {
+  // the default converter is good enough for anything that
+  // isn't influenced by parameters anyway
+  const defaultConverter = converterFactory();
+  return delegatingConverter(defaultConverter, (context: any) =>
+    converterFactory(getOptions(context, null))
+  );
+}

--- a/src/dynamic-converter.ts
+++ b/src/dynamic-converter.ts
@@ -3,13 +3,14 @@ import {
   StateConverterOptionsWithContext,
   PartialConverterFactory
 } from "./converter";
+import { FieldAccessor } from "./field-accessor";
 
 export interface DynamicOptions<O> {
-  (context: any, accessor: any): Partial<O>;
+  (context: any, accessor: FieldAccessor<any, any>): Partial<O>;
 }
 
 export interface GetContextConverter<R, V> {
-  (context: any, accessor: any): IConverter<R, V>;
+  (context: any, accessor: FieldAccessor<any, any>): IConverter<R, V>;
 }
 
 function delegatingConverter<R, V>(
@@ -50,7 +51,9 @@ export function dynamic<O, R, V>(
   // the default converter is good enough for anything that
   // isn't influenced by parameters anyway
   const defaultConverter = converterFactory();
-  return delegatingConverter(defaultConverter, (context: any, accessor: any) =>
-    converterFactory(getOptions(context, accessor))
+  return delegatingConverter(
+    defaultConverter,
+    (context: any, accessor: FieldAccessor<any, any>) =>
+      converterFactory(getOptions(context, accessor))
   );
 }

--- a/src/dynamic-converter.ts
+++ b/src/dynamic-converter.ts
@@ -9,7 +9,7 @@ export interface DynamicOptions<O> {
 }
 
 export interface GetContextConverter<R, V> {
-  (context: any): IConverter<R, V>;
+  (context: any, accessor: any): IConverter<R, V>;
 }
 
 function delegatingConverter<R, V>(
@@ -23,13 +23,22 @@ function delegatingConverter<R, V>(
     defaultControlled: defaultConverter.defaultControlled,
     neverRequired: defaultConverter.neverRequired,
     convert(raw: R, options: StateConverterOptionsWithContext) {
-      return getContextConverter(options.context).convert(raw, options);
+      return getContextConverter(options.context, options.accessor).convert(
+        raw,
+        options
+      );
     },
     render(value: V, options: StateConverterOptionsWithContext) {
-      return getContextConverter(options.context).render(value, options);
+      return getContextConverter(options.context, options.accessor).render(
+        value,
+        options
+      );
     },
     preprocessRaw(raw: R, options: StateConverterOptionsWithContext) {
-      return getContextConverter(options.context).preprocessRaw(raw, options);
+      return getContextConverter(
+        options.context,
+        options.accessor
+      ).preprocessRaw(raw, options);
     }
   };
 }
@@ -41,7 +50,7 @@ export function dynamic<O, R, V>(
   // the default converter is good enough for anything that
   // isn't influenced by parameters anyway
   const defaultConverter = converterFactory();
-  return delegatingConverter(defaultConverter, (context: any) =>
-    converterFactory(getOptions(context, null))
+  return delegatingConverter(defaultConverter, (context: any, accessor: any) =>
+    converterFactory(getOptions(context, accessor))
   );
 }

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -100,7 +100,7 @@ export class FieldAccessor<R, V> {
         this.setRaw(
           this.field.render(
             derivedValue,
-            this.state.stateConverterOptionsWithContext
+            this.state.stateConverterOptionsWithContext(this)
           )
         );
       }
@@ -147,7 +147,7 @@ export class FieldAccessor<R, V> {
     }
     return this.field.render(
       this.value,
-      this.state.stateConverterOptionsWithContext
+      this.state.stateConverterOptionsWithContext(this)
     );
   }
 
@@ -305,7 +305,9 @@ export class FieldAccessor<R, V> {
     const originalRaw = raw;
     this._raw = raw;
 
-    const stateConverterOptions = this.state.stateConverterOptionsWithContext;
+    const stateConverterOptions = this.state.stateConverterOptionsWithContext(
+      this
+    );
 
     raw = this.field.converter.preprocessRaw(raw, stateConverterOptions);
 
@@ -377,7 +379,7 @@ export class FieldAccessor<R, V> {
     // to be disabled
     this._raw = this.field.render(
       value,
-      this.state.stateConverterOptionsWithContext
+      this.state.stateConverterOptionsWithContext(this)
     );
     // trigger validation
     this.validate();

--- a/src/state.ts
+++ b/src/state.ts
@@ -240,8 +240,14 @@ export class FormState<
     return this.node;
   }
 
-  get stateConverterOptionsWithContext(): StateConverterOptionsWithContext {
-    return { context: this.context, ...this._converterOptions };
+  stateConverterOptionsWithContext(
+    accessor: any
+  ): StateConverterOptionsWithContext {
+    return {
+      context: this.context,
+      accessor: accessor,
+      ...this._converterOptions
+    };
   }
 
   @action

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -377,16 +377,14 @@ test("object converter", async () => {
 test("dynamic decimal converter", async () => {
   const context = { options: { decimalPlaces: 0 } };
 
-  function currency() {
-    return converters.decimal(context => context.options);
-  }
-
   const M = types.model("M", {
     foo: types.string
   });
 
   const form = new Form(M, {
-    foo: new Field(currency())
+    foo: new Field(
+      converters.dynamic(converters.decimal, context => context.options)
+    )
   });
 
   const o = M.create({ foo: "4" });
@@ -462,7 +460,12 @@ test("render decimal number without decimals with decimal separator", async () =
   });
 
   const form = new Form(M, {
-    foo: new Field(converters.decimal(getDecimalOptions))
+    foo: new Field(
+      converters.dynamic(converters.decimal, context => ({
+        allowNegative: false,
+        decimalPlaces: getCurrencyDecimals(context.getCurrency())
+      }))
+    )
   });
 
   function getCurrencyDecimals(currency: string) {
@@ -470,13 +473,6 @@ test("render decimal number without decimals with decimal separator", async () =
       return 2;
     }
     return 4;
-  }
-
-  function getDecimalOptions(context: any) {
-    return {
-      allowNegative: false,
-      decimalPlaces: getCurrencyDecimals(context.getCurrency())
-    };
   }
 
   const currency = "EUR";

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -6,17 +6,25 @@ import {
   Form,
   IConverter,
   converters,
-  StateConverterOptionsWithContext
+  StateConverterOptionsWithContext,
+  FieldAccessor
 } from "../src";
 import { resolveReactions } from "./utils";
+
+const baseOptions = {
+  // a BIG lie. but we don't really have an accessor in these
+  // tests and it's safe to leave it null, even though in
+  // the integrated code accessor always *does* exist
+  accessor: (null as unknown) as FieldAccessor<any, any>
+};
 
 async function check(
   converter: IConverter<any, any>,
   value: any,
   expected: any
 ) {
-  const processedValue = converter.preprocessRaw(value, {});
-  const r = await converter.convert(processedValue, {});
+  const processedValue = converter.preprocessRaw(value, baseOptions);
+  const r = await converter.convert(processedValue, baseOptions);
   expect(r).toBeInstanceOf(ConversionValue);
   expect((r as ConversionValue<any>).value).toEqual(expected);
 }
@@ -34,7 +42,7 @@ async function checkWithOptions(
 }
 
 async function fails(converter: IConverter<any, any>, value: any) {
-  const r = await converter.convert(value, {});
+  const r = await converter.convert(value, baseOptions);
   expect(r).toBe(CONVERSION_ERROR);
 }
 
@@ -61,43 +69,52 @@ test("number converter", async () => {
   await check(converters.number, "19.", 19);
   await check(converters.number, "-3.14", -3.14);
   await checkWithOptions(converters.number, "1234,56", 1234.56, {
-    decimalSeparator: ","
+    decimalSeparator: ",",
+    ...baseOptions
   });
   await checkWithOptions(converters.number, "4.000,000000", 4000, {
     decimalSeparator: ",",
-    thousandSeparator: "."
+    thousandSeparator: ".",
+    ...baseOptions
   });
   await fails(converters.number, "foo");
   await fails(converters.number, "1foo");
   await fails(converters.number, "");
   await failsWithOptions(converters.number, "1,23.45", {
     decimalSeparator: ".",
-    thousandSeparator: ","
+    thousandSeparator: ",",
+    ...baseOptions
   });
   await failsWithOptions(converters.number, ",12345", {
-    thousandSeparator: ","
+    thousandSeparator: ",",
+    ...baseOptions
   });
   await failsWithOptions(converters.number, "1234,567", {
-    thousandSeparator: ","
+    thousandSeparator: ",",
+    ...baseOptions
   });
   await failsWithOptions(converters.number, "12.3,456", {
     decimalSeparator: ".",
-    thousandSeparator: ","
+    thousandSeparator: ",",
+    ...baseOptions
   });
   await failsWithOptions(converters.number, "1.1,1", {
     decimalSeparator: ",",
-    thousandSeparator: "."
+    thousandSeparator: ".",
+    ...baseOptions
   });
   await failsWithOptions(converters.number, "1,1.1", {
     decimalSeparator: ",",
-    thousandSeparator: "."
+    thousandSeparator: ".",
+    ...baseOptions
   });
 });
 
 test("number converter with both options", async () => {
   await checkWithOptions(converters.number, "4.314.314,31", 4314314.31, {
     decimalSeparator: ",",
-    thousandSeparator: "."
+    thousandSeparator: ".",
+    ...baseOptions
   });
 });
 
@@ -122,7 +139,8 @@ test("decimal converter", async () => {
   await check(converters.decimal({}), ".14", ".14");
   await check(converters.decimal({}), "14.", "14.");
   await checkWithOptions(converters.decimal({}), "43,14", "43.14", {
-    decimalSeparator: ","
+    decimalSeparator: ",",
+    ...baseOptions
   });
   await checkWithOptions(
     converters.decimal({ decimalPlaces: 6 }),
@@ -130,7 +148,8 @@ test("decimal converter", async () => {
     "4000.000000",
     {
       decimalSeparator: ",",
-      thousandSeparator: "."
+      thousandSeparator: ".",
+      ...baseOptions
     }
   );
   await checkWithOptions(
@@ -140,7 +159,8 @@ test("decimal converter", async () => {
     {
       decimalSeparator: ",",
       thousandSeparator: ".",
-      renderThousands: true
+      renderThousands: true,
+      ...baseOptions
     }
   );
   await fails(converters.decimal({}), "foo");
@@ -152,37 +172,45 @@ test("decimal converter", async () => {
   await fails(converters.decimal({ allowNegative: false }), "-45.34");
   await failsWithOptions(converters.decimal({}), "1,23.45", {
     decimalSeparator: ".",
-    thousandSeparator: ","
+    thousandSeparator: ",",
+    ...baseOptions
   });
   await failsWithOptions(converters.decimal({}), ",12345", {
-    thousandSeparator: ","
+    thousandSeparator: ",",
+    ...baseOptions
   });
   await failsWithOptions(converters.decimal({}), "1234,567", {
-    thousandSeparator: ","
+    thousandSeparator: ",",
+    ...baseOptions
   });
   await failsWithOptions(converters.decimal({}), "12.3,456", {
     decimalSeparator: ".",
-    thousandSeparator: ","
+    thousandSeparator: ",",
+    ...baseOptions
   });
   await failsWithOptions(converters.decimal({}), "1.1,1", {
     decimalSeparator: ",",
-    thousandSeparator: "."
+    thousandSeparator: ".",
+    ...baseOptions
   });
   await failsWithOptions(converters.decimal({}), "1,1.1", {
     decimalSeparator: ",",
-    thousandSeparator: "."
+    thousandSeparator: ".",
+    ...baseOptions
   });
   await failsWithOptions(converters.decimal({}), "1234.56", {
     decimalSeparator: ",",
     thousandSeparator: ".",
-    renderThousands: true
+    renderThousands: true,
+    ...baseOptions
   });
 });
 
 test("decimal converter with both options", async () => {
   await checkWithOptions(converters.decimal({}), "4.314.314,31", "4314314.31", {
     decimalSeparator: ",",
-    thousandSeparator: "."
+    thousandSeparator: ".",
+    ...baseOptions
   });
 });
 
@@ -191,7 +219,8 @@ test("decimal converter render with renderThousands false", async () => {
   const options = {
     decimalSeparator: ",",
     thousandSeparator: ".",
-    renderThousands: false
+    renderThousands: false,
+    ...baseOptions
   };
   const value = "4.314.314,31";
   const processedValue = converter.preprocessRaw(value, options);
@@ -208,7 +237,8 @@ test("decimal converter render with six decimals", async () => {
   const options = {
     decimalSeparator: ".",
     thousandSeparator: ",",
-    renderThousands: true
+    renderThousands: true,
+    ...baseOptions
   };
   const value = "4.000000";
   const processedValue = converter.preprocessRaw(value, options);
@@ -225,7 +255,8 @@ test("decimal converter render with six decimals and thousand separators", async
   const options = {
     decimalSeparator: ".",
     thousandSeparator: ",",
-    renderThousands: true
+    renderThousands: true,
+    ...baseOptions
   };
   const value = "4000000.000000";
   const processedValue = converter.preprocessRaw(value, options);
@@ -242,7 +273,8 @@ test("decimal converter render with six decimals, only showing three", async () 
   const options = {
     decimalSeparator: ",",
     thousandSeparator: ".",
-    renderThousands: true
+    renderThousands: true,
+    ...baseOptions
   };
   const value = "4000.000000";
   const rendered = converter.render(value, options);
@@ -254,7 +286,8 @@ test("decimal converter with thousandSeparator . and no decimalSeparator can't c
   const converter = converters.decimal();
   const options = {
     thousandSeparator: ".",
-    renderThousands: true
+    renderThousands: true,
+    ...baseOptions
   };
   const value = "4.000";
   const processedValue = converter.preprocessRaw(value, options);
@@ -268,7 +301,8 @@ test("decimal converter with thousandSeparator . and no decimalSeparator can't c
 
 test("do not convert a normal string with decimal options", async () => {
   await checkWithOptions(converters.string, "43,14", "43,14", {
-    decimalSeparator: ","
+    decimalSeparator: ",",
+    ...baseOptions
   });
 });
 
@@ -291,14 +325,14 @@ test("maybe decimal converter", async () => {
   await check(converters.maybe(converters.decimal()), "3.14", "3.14");
   await check(converters.maybe(converters.decimal()), "", undefined);
   const c = converters.maybe(converters.decimal());
-  expect(c.render(undefined, {})).toEqual("");
+  expect(c.render(undefined, baseOptions)).toEqual("");
 });
 
 test("maybeNull decimal converter", async () => {
   await check(converters.maybeNull(converters.decimal()), "3.14", "3.14");
   await check(converters.maybeNull(converters.decimal()), "", null);
   const c = converters.maybeNull(converters.decimal());
-  expect(c.render(null, {})).toEqual("");
+  expect(c.render(null, baseOptions)).toEqual("");
 });
 
 test("maybe string converter", async () => {
@@ -319,9 +353,9 @@ test("model converter", async () => {
     foo: "FOO"
   });
   const converter = converters.model(M);
-  const r = await converter.convert({ foo: "value" }, {});
+  const r = await converter.convert({ foo: "value" }, baseOptions);
   expect(r).toEqual({ value: { foo: "value" } });
-  const r2 = await converter.convert(o, {});
+  const r2 = await converter.convert(o, baseOptions);
   expect(r2).toEqual({ value: o });
 });
 
@@ -333,12 +367,12 @@ test("maybe model converter", async () => {
     foo: "FOO"
   });
   const converter = converters.maybe(converters.model(M));
-  const r = await converter.convert({ foo: "value" }, {});
+  const r = await converter.convert({ foo: "value" }, baseOptions);
   expect(r).toEqual({ value: { foo: "value" } });
-  const r2 = await converter.convert(o, {});
+  const r2 = await converter.convert(o, baseOptions);
   expect(r2).toEqual({ value: o });
   // we use null as the sentinel value for raw
-  const r3 = await converter.convert(null, {});
+  const r3 = await converter.convert(null, baseOptions);
   expect(r3).toEqual({ value: undefined });
 });
 
@@ -350,11 +384,11 @@ test("maybeNull model converter", async () => {
     foo: "FOO"
   });
   const converter = converters.maybeNull(converters.model(M));
-  const r = await converter.convert({ foo: "value" }, {});
+  const r = await converter.convert({ foo: "value" }, baseOptions);
   expect(r).toEqual({ value: { foo: "value" } });
-  const r2 = await converter.convert(o, {});
+  const r2 = await converter.convert(o, baseOptions);
   expect(r2).toEqual({ value: o });
-  const r3 = await converter.convert(null, {});
+  const r3 = await converter.convert(null, baseOptions);
   expect(r3).toEqual({ value: null });
 });
 
@@ -366,11 +400,11 @@ test("object converter", async () => {
     foo: "FOO"
   });
   const converter = converters.object;
-  const r = await converter.convert({ foo: "value" }, {});
+  const r = await converter.convert({ foo: "value" }, baseOptions);
   expect(r).toEqual({ value: { foo: "value" } });
-  const r2 = await converter.convert(o, {});
+  const r2 = await converter.convert(o, baseOptions);
   expect(r2).toEqual({ value: o });
-  const r3 = await converter.convert(null, {});
+  const r3 = await converter.convert(null, baseOptions);
   expect(r3).toEqual({ value: null });
 });
 

--- a/test/derived.test.ts
+++ b/test/derived.test.ts
@@ -213,11 +213,14 @@ test("calculated with context", async () => {
   }
 
   const form = new Form(M, {
-    calculated: new Field(converters.decimal(getDecimalPlaces), {
-      derived: (node: Instance<typeof M>) => node.sum()
-    }),
-    a: new Field(converters.decimal(getDecimalPlaces)),
-    b: new Field(converters.decimal(getDecimalPlaces))
+    calculated: new Field(
+      converters.dynamic(converters.decimal, getDecimalPlaces),
+      {
+        derived: (node: Instance<typeof M>) => node.sum()
+      }
+    ),
+    a: new Field(converters.dynamic(converters.decimal, getDecimalPlaces)),
+    b: new Field(converters.dynamic(converters.decimal, getDecimalPlaces))
   });
 
   const o = M.create({ calculated: "0.0000", a: "1.0000", b: "2.3456" });

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -32,14 +32,3 @@ test("dynamic based on accessor", async () => {
   await bar.setRaw("-3.4");
   expect(bar.error).toBeUndefined();
 });
-
-// test("map conversion error types", () => {
-//   const form = new Form(M, {
-//     foo: new Field(converters.decimal(), {
-//       conversionError: (context, errorType) => { return "Foo"}
-//     })
-//   }, {}, {conversionErrors: { converters.decimal: (context, errorType) => ({})});
-// });
-
-// is there a way to create decimal options that are global for the whole form?
-// for instance whether to use a . or , for the decimal separator.

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -1,5 +1,5 @@
 import { types } from "mobx-state-tree";
-import { converters, Field, Form } from "../src";
+import { converters, Field, Form, FieldAccessor } from "../src";
 
 test("dynamic based on accessor", async () => {
   const M = types.model("M", {
@@ -7,7 +7,7 @@ test("dynamic based on accessor", async () => {
     bar: types.string
   });
 
-  const getOptions = (context: any, accessor: any) => {
+  const getOptions = (context: any, accessor: FieldAccessor<any, any>) => {
     if (accessor.fieldref === "foo") {
       return { allowNegative: false };
     } else {

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -32,3 +32,59 @@ test("dynamic based on accessor", async () => {
   await bar.setRaw("-3.4");
   expect(bar.error).toBeUndefined();
 });
+
+test("dynamic converter with maybe", async () => {
+  const M = types.model("M", {
+    foo: types.maybe(types.string)
+  });
+
+  const getOptions = (context: any, accessor: FieldAccessor<any, any>) => {
+    return { allowNegative: false };
+  };
+
+  const form = new Form(M, {
+    foo: new Field(
+      converters.maybe(converters.dynamic(converters.decimal, getOptions))
+    )
+  });
+
+  const o = M.create({ foo: "1.2" });
+
+  const state = form.state(o);
+  const foo = state.field("foo");
+
+  await foo.setRaw("-1.2");
+  expect(foo.error).toEqual("Could not convert");
+
+  await foo.setRaw("");
+  expect(foo.error).toBeUndefined();
+  expect(foo.value).toBeUndefined();
+});
+
+test("dynamic converter with maybeNull", async () => {
+  const M = types.model("M", {
+    foo: types.maybeNull(types.string)
+  });
+
+  const getOptions = (context: any, accessor: FieldAccessor<any, any>) => {
+    return { allowNegative: false };
+  };
+
+  const form = new Form(M, {
+    foo: new Field(
+      converters.maybeNull(converters.dynamic(converters.decimal, getOptions))
+    )
+  });
+
+  const o = M.create({ foo: "1.2" });
+
+  const state = form.state(o);
+  const foo = state.field("foo");
+
+  await foo.setRaw("-1.2");
+  expect(foo.error).toEqual("Could not convert");
+
+  await foo.setRaw("");
+  expect(foo.error).toBeUndefined();
+  expect(foo.value).toBeNull();
+});

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -1,0 +1,45 @@
+import { types } from "mobx-state-tree";
+import { converters, Field, Form } from "../src";
+
+test("dynamic based on accessor", async () => {
+  const M = types.model("M", {
+    foo: types.string,
+    bar: types.string
+  });
+
+  const getOptions = (context: any, accessor: any) => {
+    if (accessor.fieldref === "foo") {
+      return { allowNegative: false };
+    } else {
+      return { allowNegative: true };
+    }
+  };
+
+  const form = new Form(M, {
+    foo: new Field(converters.dynamic(converters.decimal, getOptions)),
+    bar: new Field(converters.dynamic(converters.decimal, getOptions))
+  });
+
+  const o = M.create({ foo: "1.2", bar: "3.4" });
+
+  const state = form.state(o);
+  const foo = state.field("foo");
+  const bar = state.field("bar");
+
+  await foo.setRaw("-1.2");
+  expect(foo.error).toEqual("Could not convert");
+
+  await bar.setRaw("-3.4");
+  expect(bar.error).toBeUndefined();
+});
+
+// test("map conversion error types", () => {
+//   const form = new Form(M, {
+//     foo: new Field(converters.decimal(), {
+//       conversionError: (context, errorType) => { return "Foo"}
+//     })
+//   }, {}, {conversionErrors: { converters.decimal: (context, errorType) => ({})});
+// });
+
+// is there a way to create decimal options that are global for the whole form?
+// for instance whether to use a . or , for the decimal separator.

--- a/yarn.lock
+++ b/yarn.lock
@@ -8658,10 +8658,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
-  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
+typescript@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.1.tgz#b6691be11a881ffa9a05765a205cb7383f3b63c6"
+  integrity sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==
 
 ua-parser-js@^0.7.18:
   version "0.7.18"


### PR DESCRIPTION
Introduce `converters.dynamic`, which allows us to make arbitrary converters (that take parameters) dynamic.

Also prepare the converters by creating lots of `WithOptions` variants of converters. These don't actually take any real options yet, but they can in the future.