### PR TITLE
Don't trigger the change hook if nothing changed.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.11.1
+
+-   Fix: it was possible for the change hook to be triggered for a field even
+    if the field actually did not change, at least if that field was required
+    and empty.
+
 # 1.11.0
 
 -   There is a new `backend` configuration option where you can configure

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -163,6 +163,11 @@ export class FieldAccessor<R, V> {
 
   @action
   setValue(value: V) {
+    // if there are no changes, don't do anything
+    if (comparer.structural(this._value, value)) {
+      return;
+    }
+
     this._value = value;
     this.state.setValueWithoutRawUpdate(this.path, value);
     // XXX maybe rename this to 'update' as change might imply onChange
@@ -346,11 +351,6 @@ export class FieldAccessor<R, V> {
     // XXX possible flicker?
     if (typeof extraResult === "string" && extraResult) {
       this.setError(extraResult);
-    }
-
-    // if there are no changes, don't do anything
-    if (comparer.structural(this.value, processResult.value)) {
-      return;
     }
 
     this.setValue(processResult.value);


### PR DESCRIPTION
We have some weird behavior where processing is triggered even though we think it shouldn't. I noticed a code path where the change hook was triggered even though the value hadn't changed. I added tests to demonstrate this (the situation with required was the problem) and moved the check to see whether changes were actually made to a better place. 