### PR TITLE
Defaults for add mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+# 1.13.0
+
+-   When you `push` or `insert` a new repeating form item you can now pass a
+    third argument which is a list of fieldrefs. Each fieldref indicates a field
+    where you want this field to start outside of add-mode; that field has its
+    raw reflecting that of the value, unlike other fields in add-mode.
+
+    You can give a `addModeDefaults` option when you call `state()`, which can be
+    used to exclude certain items from add-mode in the entire form.
+
 # 1.12.1
 
 -   `processAll` did not clear errors and warnings when we ran it, leaving old

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
     You can give a `addModeDefaults` option when you call `state()`, which can be
     used to exclude certain items from add-mode in the entire form.
 
+    If you use `addModeDefaults` with a field that is derived, the derived
+    value is calculated right away.
+
 # 1.12.1
 
 -   `processAll` did not clear errors and warnings when we ran it, leaving old

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
     If you use `addModeDefaults` with a field that is derived, the derived
     value is calculated right away.
 
+-   Fix: too many accessors were initialized. This was generally not a problem
+    except that if you derived a field from another it would be called
+    excessively often.
+
 # 1.12.1
 
 -   `processAll` did not clear errors and warnings when we ran it, leaving old

--- a/README.md
+++ b/README.md
@@ -720,6 +720,17 @@ you use the `.push` and `.insert` methods on the repeating form accessor, or if
 you manipulate the underlying model directly. Existing records are shown in
 edit mode, unless the whole form is in add mode.
 
+If you use `.push` and `.insert` on the repeating form accessor, you can pass
+in an additional argument with the `addModeDefaults` array. Here is an example:
+
+```js
+repeating.push({ a: 3, b: 5 }, ["b"]);
+```
+
+Here `a` is not mentioned and is considered to be in add-mode; instead of its
+value, the empty raw is shown instead. But `b` is referenced and therefore `5`
+is visible immediately in the form.
+
 ## Backend interaction (save and processing)
 
 When we create the form state, we can pass it options on how to interact with

--- a/README.md
+++ b/README.md
@@ -701,6 +701,16 @@ what empty values to display in an add form? The converter actually specifies
 this -- `converters.number` for instance knows that the empty value is the
 empty string.
 
+In case you already have a default value for a field and you do not want it to
+be in add-mode, you can exclude them by including its fieldref in the
+`addModeDefaults` option:
+
+```js
+const state = form.state(node, { addMode: true, addModeDefaults: ["nr"] });
+```
+
+Now the `nr` field is shown with the value `0` in it immediately.
+
 ### Add mode for repeating forms
 
 Consider a repeating sub-form. Adding a new entry to a sub-form is much like

--- a/README.md
+++ b/README.md
@@ -711,6 +711,9 @@ const state = form.state(node, { addMode: true, addModeDefaults: ["nr"] });
 
 Now the `nr` field is shown with the value `0` in it immediately.
 
+If the field you reference from `addModeDefaults` is configured to be derived,
+this is used to calculate the derived value automatically.
+
 ### Add mode for repeating forms
 
 Consider a repeating sub-form. Adding a new entry to a sub-form is much like

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.12.1",
+    "version": "1.13.0",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.12.0",
+    "version": "1.12.1",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/addMode.ts
+++ b/src/addMode.ts
@@ -15,7 +15,13 @@ export function setAddModeDefaults(
   baseAccessor.accessors.forEach(accessor => {
     if (accessor instanceof FieldAccessor) {
       if (fieldrefSet.has(accessor.fieldref)) {
-        accessor.setRawFromValue();
+        if (accessor.field.derivedFunc == null) {
+          accessor.setRawFromValue();
+        } else {
+          accessor.setValueAndUpdateRaw(
+            accessor.field.derivedFunc(accessor.node)
+          );
+        }
       }
     }
   });

--- a/src/addMode.ts
+++ b/src/addMode.ts
@@ -1,0 +1,22 @@
+import { FormAccessor } from "./form-accessor";
+import { FieldAccessor } from "./field-accessor";
+
+export function setAddModeDefaults(
+  baseAccessor: FormAccessor<any, any>,
+  addModeDefaults: string[]
+) {
+  const fieldrefSet = new Set<string>();
+  const fieldrefPrefix =
+    baseAccessor.fieldref !== "" ? baseAccessor.fieldref + "." : "";
+
+  addModeDefaults.forEach(fieldref => {
+    fieldrefSet.add(fieldrefPrefix + fieldref);
+  });
+  baseAccessor.accessors.forEach(accessor => {
+    if (accessor instanceof FieldAccessor) {
+      if (fieldrefSet.has(accessor.fieldref)) {
+        accessor.setRawFromValue();
+      }
+    }
+  });
+}

--- a/src/addMode.ts
+++ b/src/addMode.ts
@@ -18,7 +18,7 @@ export function setAddModeDefaults(
         if (accessor.field.derivedFunc == null) {
           accessor.setRawFromValue();
         } else {
-          accessor.setValueAndUpdateRaw(
+          accessor.setValueAndRawWithoutChangeEvent(
             accessor.field.derivedFunc(accessor.node)
           );
         }

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -185,6 +185,21 @@ export class FieldAccessor<R, V> {
     }
   }
 
+  @action
+  setValueAndRawWithoutChangeEvent(value: V) {
+    // if there are no changes, don't do anything
+    if (comparer.structural(this._value, value)) {
+      return;
+    }
+
+    this._value = value;
+    this.state.setValueWithoutRawUpdate(this.path, value);
+    this._raw = this.field.render(
+      value,
+      this.state.stateConverterOptionsWithContext(this)
+    );
+  }
+
   @computed
   get value(): V {
     if (this.addMode) {

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -102,7 +102,9 @@ export class FieldAccessor<R, V> {
     // try to do any work. This isn't ideal but can happen
     // if the path a node was pointing to has been removed.
     const disposer = reaction(
-      () => (this.node ? derivedFunc(this.node) : undefined),
+      () => {
+        return this.node != null ? derivedFunc(this.node) : undefined;
+      },
       (derivedValue: any) => {
         if (derivedValue === undefined) {
           return;

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -273,7 +273,6 @@ export class FormAccessor<
       name as string
     );
     this.subFormAccessors.set(name, result);
-    result.initialize();
   }
 
   subForm<K extends keyof D>(name: K): SubFormAccess<D, K> {

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -7,6 +7,7 @@ import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor"
 import { FormAccessor } from "./form-accessor";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
+import { FieldAccessor } from "./field-accessor";
 
 export class RepeatingFormAccessor<
   D extends FormDefinition<any>,
@@ -155,18 +156,19 @@ export class RepeatingFormAccessor<
     return accessor.accessBySteps(rest);
   }
 
-  insert(index: number, node: any) {
+  insert(index: number, node: any, addModeDefaults: string[] = []) {
     const path = this.path + "/" + index;
     applyPatch(this.state.node, [{ op: "add", path, value: node }]);
-    this.index(index).setAddMode();
+    this.index(index).setAddMode(addModeDefaults);
   }
 
-  push(node: any) {
+  push(node: any, addModeDefaults: string[] = []) {
     const a = this.value;
     const index = a.length;
     const path = this.path + "/" + index;
     applyPatch(this.state.node, [{ op: "add", path, value: node }]);
-    this.index(index).setAddMode();
+    const indexedAccessor = this.index(index);
+    indexedAccessor.setAddMode(addModeDefaults);
   }
 
   remove(node: any) {

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -7,7 +7,6 @@ import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor"
 import { FormAccessor } from "./form-accessor";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
-import { FieldAccessor } from "./field-accessor";
 
 export class RepeatingFormAccessor<
   D extends FormDefinition<any>,

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -92,7 +92,6 @@ export class RepeatingFormAccessor<
       index
     );
     this.repeatingFormIndexedAccessors.set(index, result);
-    result.initialize();
   }
 
   index(index: number): RepeatingFormIndexedAccessor<D, G> {

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -3,6 +3,7 @@ import { action, observable, computed } from "mobx";
 import { FormDefinition, GroupDefinition } from "./form";
 import { FormState } from "./state";
 import { RepeatingFormAccessor } from "./repeating-form-accessor";
+import { FieldAccessor } from "./field-accessor";
 import { FormAccessorBase } from "./form-accessor-base";
 import { FormAccessor } from "./form-accessor";
 import { pathToFieldref } from "./utils";
@@ -89,8 +90,19 @@ export class RepeatingFormIndexedAccessor<
   }
 
   @action
-  setAddMode() {
+  setAddMode(addModeDefaults: string[]) {
     this._addMode = true;
+    const fieldrefSet = new Set<string>();
+    addModeDefaults.forEach(fieldref => {
+      fieldrefSet.add(this.fieldref + "." + fieldref);
+    });
+    this.accessors.forEach(accessor => {
+      if (accessor instanceof FieldAccessor) {
+        if (fieldrefSet.has(accessor.fieldref)) {
+          accessor.setRawFromValue();
+        }
+      }
+    });
   }
 
   @computed

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -3,7 +3,7 @@ import { action, observable, computed } from "mobx";
 import { FormDefinition, GroupDefinition } from "./form";
 import { FormState } from "./state";
 import { RepeatingFormAccessor } from "./repeating-form-accessor";
-import { FieldAccessor } from "./field-accessor";
+import { setAddModeDefaults } from "./addMode";
 import { FormAccessorBase } from "./form-accessor-base";
 import { FormAccessor } from "./form-accessor";
 import { pathToFieldref } from "./utils";
@@ -92,17 +92,7 @@ export class RepeatingFormIndexedAccessor<
   @action
   setAddMode(addModeDefaults: string[]) {
     this._addMode = true;
-    const fieldrefSet = new Set<string>();
-    addModeDefaults.forEach(fieldref => {
-      fieldrefSet.add(this.fieldref + "." + fieldref);
-    });
-    this.accessors.forEach(accessor => {
-      if (accessor instanceof FieldAccessor) {
-        if (fieldrefSet.has(accessor.fieldref)) {
-          accessor.setRawFromValue();
-        }
-      }
-    });
+    setAddModeDefaults(this.formAccessor, addModeDefaults);
   }
 
   @computed

--- a/src/state.ts
+++ b/src/state.ts
@@ -34,6 +34,7 @@ import {
   SaveFunc,
   ProcessAll
 } from "./backend";
+import { setAddModeDefaults } from "./addMode";
 
 export interface AccessorAllows {
   (accessor: Accessor): boolean;
@@ -204,17 +205,9 @@ export class FormState<
 
     checkConverterOptions(this._converterOptions);
 
-    const fieldrefSet = new Set<string>();
-    addModeDefaults.forEach(fieldref => {
-      fieldrefSet.add(fieldref);
-    });
-    this.accessors.forEach(accessor => {
-      if (accessor instanceof FieldAccessor) {
-        if (fieldrefSet.has(accessor.fieldref)) {
-          accessor.setRawFromValue();
-        }
-      }
-    });
+    if (addMode) {
+      setAddModeDefaults(this.formAccessor, addModeDefaults);
+    }
 
     if (backend != null) {
       const processor = new Backend(

--- a/src/state.ts
+++ b/src/state.ts
@@ -97,6 +97,8 @@ export interface FormStateOptions<M> {
   context?: any;
   converterOptions?: StateConverterOptions;
   requiredError?: string | ErrorFunc;
+
+  addModeDefaults?: string[];
 }
 
 export type SaveStatusOptions = "before" | "rightAfter" | "after";
@@ -151,7 +153,8 @@ export class FormState<
       update,
       context,
       converterOptions = {},
-      requiredError = "Required"
+      requiredError = "Required",
+      addModeDefaults = []
     }: FormStateOptions<M> = {}
   ) {
     super();
@@ -200,6 +203,18 @@ export class FormState<
     this._requiredError = requiredError;
 
     checkConverterOptions(this._converterOptions);
+
+    const fieldrefSet = new Set<string>();
+    addModeDefaults.forEach(fieldref => {
+      fieldrefSet.add(fieldref);
+    });
+    this.accessors.forEach(accessor => {
+      if (accessor instanceof FieldAccessor) {
+        if (fieldrefSet.has(accessor.fieldref)) {
+          accessor.setRawFromValue();
+        }
+      }
+    });
 
     if (backend != null) {
       const processor = new Backend(

--- a/src/state.ts
+++ b/src/state.ts
@@ -178,7 +178,6 @@ export class FormState<
       null,
       addMode
     );
-    this.formAccessor.initialize();
 
     this.isDisabledFunc = isDisabled;
     this.isHiddenFunc = isHidden;

--- a/test/derived.test.ts
+++ b/test/derived.test.ts
@@ -242,7 +242,7 @@ test("calculated with addModeDefaults", () => {
 
   // we now change a, which should modify the derived value
   sub0.field("a").setRaw("3");
-  //  expect(changeCount).toBe(1);
+  expect(changeCount).toBe(1);
   expect(calculated0.value).toEqual(5);
   expect(calculated0.raw).toEqual("5");
 
@@ -253,7 +253,7 @@ test("calculated with addModeDefaults", () => {
   expect(calculated1.value).toEqual(8);
 
   sub1.field("a").setRaw("6");
-  // expect(changeCount).toBe(2);
+  expect(changeCount).toBe(2);
   // we should have calculated the derived
   expect(calculated1.value).toEqual(9);
   expect(calculated1.raw).toEqual("9");
@@ -265,6 +265,7 @@ test("calculated with addModeDefaults", () => {
   const calculated2 = sub2.field("calculated");
   expect(calculated2.value).toEqual(8);
   expect(calculated2.raw).toEqual("8");
+  expect(changeCount).toBe(2);
 });
 
 test("calculated with context", () => {
@@ -350,10 +351,10 @@ test("dispose", () => {
   // previous state is important to do test dispose
   // happens properly, don't remove!
   const previousState = form.state(o);
-  expect(counter).toBe(2);
+  expect(counter).toBe(1);
 
   const state = form.state(o);
-  expect(counter).toBe(4);
+  expect(counter).toBe(2);
 
   const calculated = state.field("calculated");
   const a = state.field("a");
@@ -369,14 +370,14 @@ test("dispose", () => {
   // this immediately affects the underlying value
   expect(calculated.value).toEqual(4);
 
-  expect(counter).toBe(4);
+  expect(counter).toBe(2);
 
   // we now change a, which should modify the derived value
   a.setRaw("3");
 
   // if we hadn't disposed properly this would have been
   // called more
-  expect(counter).toBe(7);
+  expect(counter).toBe(3);
 
   expect(calculated.raw).toEqual("5");
   // and also the underlying value, immediately

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -214,9 +214,15 @@ test("repeating form push, with default fieldrefs", () => {
     foo: types.array(N)
   });
 
+  let changeCount = 0;
+
   const form = new Form(M, {
     foo: new RepeatingForm({
-      bar: new Field(converters.string)
+      bar: new Field(converters.string, {
+        change: () => {
+          changeCount++;
+        }
+      })
     })
   });
 
@@ -236,6 +242,8 @@ test("repeating form push, with default fieldrefs", () => {
   expect(field.raw).toEqual("QUX");
 
   expect(forms.index(0).field("bar").raw).toEqual("BAR");
+  // no change events
+  expect(changeCount).toBe(0);
 });
 
 test("repeating form insert", () => {

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -206,6 +206,38 @@ test("repeating form push", () => {
   expect(forms.index(0).field("bar").raw).toEqual("BAR");
 });
 
+test("repeating form push, with default fieldrefs", () => {
+  const N = types.model("N", {
+    bar: types.string
+  });
+  const M = types.model("M", {
+    foo: types.array(N)
+  });
+
+  const form = new Form(M, {
+    foo: new RepeatingForm({
+      bar: new Field(converters.string)
+    })
+  });
+
+  const o = M.create({ foo: [{ bar: "BAR" }] });
+
+  const state = form.state(o);
+
+  const forms = state.repeatingForm("foo");
+  expect(forms.length).toBe(1);
+  forms.push({ bar: "QUX" }, ["bar"]);
+  expect(forms.length).toBe(2);
+
+  const oneForm = forms.index(1);
+  const field = oneForm.field("bar");
+
+  // not in add mode
+  expect(field.raw).toEqual("QUX");
+
+  expect(forms.index(0).field("bar").raw).toEqual("BAR");
+});
+
 test("repeating form insert", () => {
   const N = types.model("N", {
     bar: types.string
@@ -235,6 +267,42 @@ test("repeating form insert", () => {
   // this thing is in add mode
   expect(field.addMode).toBeTruthy();
   expect(field.raw).toEqual("");
+
+  field.setRaw("FLURB");
+  expect(field.addMode).toBeFalsy();
+  expect(field.raw).toEqual("FLURB");
+  expect(field.value).toEqual("FLURB");
+});
+
+test("repeating form insert with default fieldrefs", () => {
+  const N = types.model("N", {
+    bar: types.string
+  });
+  const M = types.model("M", {
+    foo: types.array(N)
+  });
+
+  const form = new Form(M, {
+    foo: new RepeatingForm({
+      bar: new Field(converters.string)
+    })
+  });
+
+  const o = M.create({ foo: [{ bar: "BAR" }] });
+
+  const state = form.state(o);
+
+  const forms = state.repeatingForm("foo");
+  expect(forms.length).toBe(1);
+  forms.insert(0, { bar: "QUX" }, ["bar"]);
+  expect(forms.length).toBe(2);
+
+  const oneForm = forms.index(0);
+  const field = oneForm.field("bar");
+
+  // bar is not in add mode
+  expect(field.addMode).toBeFalsy();
+  expect(field.raw).toEqual("QUX");
 
   field.setRaw("FLURB");
   expect(field.addMode).toBeFalsy();
@@ -1222,6 +1290,29 @@ test("add mode for flat form, maybeNull number", () => {
   field.setRaw("");
   expect(field.value).toEqual(null);
   expect(field.addMode).toBeFalsy();
+  field.setRaw("3");
+  expect(field.value).toEqual(3);
+  expect(field.raw).toEqual("3");
+  expect(field.addMode).toBeFalsy();
+});
+
+test("add mode for flat form, number, defaults", () => {
+  const M = types.model("M", {
+    foo: types.number
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.number)
+  });
+
+  const o = M.create({ foo: 0 });
+
+  const state = form.state(o, { addMode: true, addModeDefaults: ["foo"] });
+  const field = state.field("foo");
+
+  expect(field.value).toBe(0);
+  expect(field.addMode).toBeFalsy();
+  expect(field.raw).toEqual("0");
   field.setRaw("3");
   expect(field.value).toEqual(3);
   expect(field.raw).toEqual("3");


### PR DESCRIPTION
You can pass 'addModeDefaults' into .push, insert and into the form options when you create state. This will cause the value you set to be used immediately (and the field is not in add mode). If the field is derived this calculation is made for you automatically as well.