### PR TITLE
Decimal converter symmetry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,11 @@
     except that if you derived a field from another it would be called
     excessively often.
 
+-   Add a `normalizedDecimalPlaces` option to the `decimal` converter. This
+    ensures that the converted decimal has a fixed number of decimal places.
+    This is useful if your backend delivers a fixed amount of decimal places
+    and you want to display less of them (with `decimalPlaces`) than you store.
+
 # 1.12.1
 
 -   `processAll` did not clear errors and warnings when we ran it, leaving old

--- a/README.md
+++ b/README.md
@@ -358,7 +358,9 @@ other object:
     `decimalPlaces` (default 2) after the period. `decimalPlaces` also controls
     the number of decimals that is initially rendered when opening the form.
     With `allowNegative` (boolean, default true) you can specify if negative
-    values are allowed.
+    values are allowed. With `normalizedDecimalPlaces` you can set the amount
+    of decimal places the converted number has. It should not be lower than
+    `decimalPlaces`, but can be higher.
 
     Conversion error types are:
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ other object:
     With `allowNegative` (boolean, default true) you can specify if negative
     values are allowed. With `normalizedDecimalPlaces` you can set the amount
     of decimal places the converted number has. It should not be lower than
-    `decimalPlaces`, but can be higher.
+    `decimalPlaces`, but can be higher. If it is, the given number is
+    automatically padded with additional decimal places set to 0.
 
     Conversion error types are:
 

--- a/src/decimalParser.ts
+++ b/src/decimalParser.ts
@@ -38,6 +38,7 @@ export type DecimalOptions = {
   decimalPlaces: number;
   addZeroes: boolean;
   allowNegative: boolean;
+  normalizedDecimalPlaces?: number;
 };
 
 type TokenOptions = {
@@ -126,10 +127,21 @@ export function parseDecimal(s: string, options: Options): string {
 
   // note that the tokenizer has replaced the decimal separator
   // with the standard "." at this point.
-  return tokens
+  const converted = tokens
     .filter(token => token.type !== TOKEN_THOUSAND_SEPARATOR)
     .map(token => token.value)
     .join("");
+  if (options.normalizedDecimalPlaces == null) {
+    return converted;
+  }
+  return normalize(converted, options.normalizedDecimalPlaces);
+}
+
+function normalize(decimal: string, amount: number): string {
+  const parts = decimal.split(".");
+  const beforePeriod = parts[0];
+  const decimals = parts.length === 2 ? parts[1] : "";
+  return beforePeriod + "." + addZeroes(decimals, amount);
 }
 
 function getWholeDigitAmount(tokens: Token[]): number {

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -201,6 +201,44 @@ test("decimal converter", () => {
   });
 });
 
+test("decimal converter with normalizedDecimalPlaces", () => {
+  const options = { normalizedDecimalPlaces: 4 };
+
+  check(converters.decimal(options), "3", "3.0000");
+  check(converters.decimal(options), "3.14", "3.1400");
+  check(converters.decimal(options), "43.14", "43.1400");
+  check(converters.decimal(options), "4313", "4313.0000");
+  check(converters.decimal(options), "-3.14", "-3.1400");
+  check(converters.decimal(options), "0", "0.0000");
+  check(converters.decimal(options), ".14", ".1400");
+  check(converters.decimal(options), "14.", "14.0000");
+  checkWithOptions(converters.decimal(options), "43,14", "43.1400", {
+    decimalSeparator: ",",
+    ...baseOptions
+  });
+  checkWithOptions(
+    converters.decimal({ decimalPlaces: 6, normalizedDecimalPlaces: 7 }),
+    "4.000,000000",
+    "4000.0000000",
+    {
+      decimalSeparator: ",",
+      thousandSeparator: ".",
+      ...baseOptions
+    }
+  );
+  checkWithOptions(
+    converters.decimal({ decimalPlaces: 2, normalizedDecimalPlaces: 4 }),
+    "36.365,21",
+    "36365.2100",
+    {
+      decimalSeparator: ",",
+      thousandSeparator: ".",
+      renderThousands: true,
+      ...baseOptions
+    }
+  );
+});
+
 test("decimal converter with both options", () => {
   checkWithOptions(converters.decimal({}), "4.314.314,31", "4314314.31", {
     decimalSeparator: ",",

--- a/test/decimalParser.test.ts
+++ b/test/decimalParser.test.ts
@@ -118,6 +118,23 @@ test("decimalPlaces", () => {
   expect(() => parseDecimal("-123.12345", options)).toThrow();
 });
 
+test("normalizedDecimalPlaces", () => {
+  const options = {
+    maxWholeDigits: 50,
+    decimalPlaces: 2,
+    normalizedDecimalPlaces: 4,
+    allowNegative: true,
+    decimalSeparator: ".",
+    thousandSeparator: ",",
+    renderThousands: true,
+    addZeroes: true
+  };
+  expect(parseDecimal("12,345.45", options)).toEqual("12345.4500");
+  expect(parseDecimal(".12", options)).toEqual(".1200");
+  expect(parseDecimal("3", options)).toEqual("3.0000");
+  expect(parseDecimal("-4", options)).toEqual("-4.0000");
+});
+
 test("numbers without thousand separators", () => {
   // as a special case we accept numbers without thousand separators too
   expect(parseDecimal("1000", options)).toEqual("1000");


### PR DESCRIPTION
Introduce normalizedDecimalPlaces. This controls the amount of decimal places that come *out* of the conversion process, while 'decimalPlaces' controls the decimal places the user is allowed to input.

By using normalizedDecimalPlaces we can ensure that if a value starts with a fixed amount of decimal places it stays at this amount of decimal places, even if the user enters less of them.