### PR TITLE
Backend live improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+# 1.14.0
+
+-   The `process` and `processAll` functions for the backend now receive a third
+    parameter, `liveOnly`. `liveOnly` is `true` before you save for the first
+    time, and after that it's `false`. This allows you to create backend
+    validation code that only runs after the first save.
+
+-   New method `resetSaveStatus` which resets the save status to `before`.
+
+-   There is a new validation option `ignoreSaveStatus` which you can pass to
+    the `save` method of the form state. This allows a save without updating the
+    save status (leaving it on `before`).
+
 # 1.13.0
 
 -   When you `push` or `insert` a new repeating form item you can now pass a

--- a/README.md
+++ b/README.md
@@ -844,7 +844,7 @@ default values for fields and clear them if they become invalid.
 Here is how we configure it (in addition to `save`):
 
 ```js
-async function process(node, path) {
+async function process(node, path, liveOnly) {
     // we have defined a real 'process' function on the model that knows how
     // to invoke process on the backend. returns ProcessResult
     return node.process();
@@ -857,7 +857,10 @@ this.formState = form.state(o, {
 
 The `node` argument is the underlying node that the form represents. `path` is
 a JSON pointer (aka MST node path) to the field that was just changed by the
-user modifying the form. The function should return a `ProcessResult`
+user modifying the form. `liveOnly` is a boolean value and is set to `true`
+before you `invoked` save. This can be used to distinguish between "live
+validations" (which always run) from those that only start running after you
+attempt a save for the first time. The function should return a `ProcessResult`
 structure.
 
 The system keeps track of which field paths have been changed by the user. It
@@ -889,7 +892,7 @@ itself: run the backend process for the entire form at once. For this we have
 Here is how we configure it (in addition to `save` and `process`):
 
 ```js
-async function processAll(node) {
+async function processAll(node, liveOnly) {
     // we have defined a real 'processAll' function on the model that knows how
     // to invoke processAll on the backend. returns ProcessResult
     return node.processAll();
@@ -1085,6 +1088,19 @@ raw value that cannot be successfully converted.
 If you only define a `save` function for your backend and no `process` function
 `ignoreGetError` is enabled automatically. This is to allow you to still save
 forms even though they have externally defined errors.
+
+### Ignoring the `saveStatus`.
+
+You can cause `save` to not affect the save status when you save::
+
+```js
+this.formState.save({ ignoreSaveStatus: true});
+```
+
+This causes the save status to remain `before`. Normally the save status is
+updated to `after` when you save, which can affect the display of validation
+messages and the state of the `liveOnly` flag that is passed to backend
+`process` and `processAll`.
 
 ### Controlling validation messages
 

--- a/README.md
+++ b/README.md
@@ -1094,7 +1094,7 @@ forms even though they have externally defined errors.
 You can cause `save` to not affect the save status when you save::
 
 ```js
-this.formState.save({ ignoreSaveStatus: true});
+this.formState.save({ ignoreSaveStatus: true });
 ```
 
 This causes the save status to remain `before`. Normally the save status is
@@ -1132,6 +1132,11 @@ this.formState = form.state(o, {
 In this case the user only sees updated validation errors once they press the
 button that triggers `state.save()` and no errors are generated when the user
 is filling in the form.
+
+If you use `ignoreSaveStatus` the save status is not affect and remains
+`before`.
+
+You can reset the save status back to `before` with `'resetSaveStatus()`.
 
 ## required fields
 

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -97,8 +97,7 @@ export class Backend<M extends IAnyModelType> {
     const processResult = await this.save(this.node);
 
     if (processResult == null) {
-      this.errorValidations.clear();
-      this.warningValidations.clear();
+      this.clearValidations();
       return true;
     }
     const completeProcessResult: ProcessResult = {
@@ -118,8 +117,7 @@ export class Backend<M extends IAnyModelType> {
       );
     }
     const processResult = await this.processAll(this.node, this.getLiveOnly());
-    this.errorValidations.clear();
-    this.warningValidations.clear();
+    this.clearValidations();
 
     const completeProcessResult: ProcessResult = {
       updates: [],
@@ -128,6 +126,11 @@ export class Backend<M extends IAnyModelType> {
       ...processResult
     };
     this.runProcessResult(completeProcessResult);
+  }
+
+  async clearValidations() {
+    this.errorValidations.clear();
+    this.warningValidations.clear();
   }
 
   async realProcess(path: string) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -209,12 +209,17 @@ export class FormState<
     }
 
     if (backend != null) {
+      const getLiveOnly = () => {
+        return this.saveStatus === "before";
+      };
+
       const processor = new Backend(
         node,
         backend.save,
         backend.process,
         backend.processAll,
-        backend
+        backend,
+        getLiveOnly
       );
       this.processor = processor;
       this.getErrorFunc = (accessor: Accessor): string | undefined => {

--- a/src/state.ts
+++ b/src/state.ts
@@ -379,12 +379,9 @@ export class FormState<
   }
 
   @action
-  async save(options?: ValidateOptions): Promise<boolean> {
+  async save(options: ValidateOptions = {}): Promise<boolean> {
     if (this.processor == null) {
       throw new Error("Cannot save without backend configuration");
-    }
-    if (options == null) {
-      options = {};
     }
     let extraOptions = {};
     if (this.processor.process == null) {
@@ -401,13 +398,19 @@ export class FormState<
       this.validate(extraOptions);
     }
 
-    this.setSaveStatus("rightAfter");
-
+    if (!options.ignoreSaveStatus) {
+      this.setSaveStatus("rightAfter");
+    }
     if (!isValid) {
       return false;
     }
 
     return this.processor.realSave();
+  }
+
+  @action
+  async resetSaveStatus() {
+    this.setSaveStatus("before");
   }
 
   @action

--- a/src/validate-options.ts
+++ b/src/validate-options.ts
@@ -1,4 +1,5 @@
 export interface ValidateOptions {
   ignoreRequired?: boolean;
   ignoreGetError?: boolean;
+  ignoreSaveStatus?: boolean;
 }

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -760,3 +760,73 @@ test("processAll and liveOnly", async () => {
 
   expect(liveSeen).toEqual([true, false]);
 });
+
+test("reset liveOnly status", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const liveSeen: boolean[] = [];
+
+  async function myProcess(
+    node: Instance<typeof M>,
+    path: string,
+    liveOnly: boolean
+  ) {
+    liveSeen.push(liveOnly);
+    return {
+      updates: [],
+      errorValidations: [],
+      warningValidations: []
+    };
+  }
+
+  async function mySave(node: Instance<typeof M>) {
+    return null;
+  }
+
+  const state = form.state(o, {
+    backend: {
+      process: myProcess,
+      save: mySave,
+      debounce: debounce
+    }
+  });
+
+  const fooField = state.field("foo");
+
+  // before a save, we only want the live fields
+  fooField.setRaw("FOO!");
+
+  jest.runAllTimers();
+  await state.processPromise;
+
+  expect(liveSeen).toEqual([true]);
+
+  // a successful save
+  const success = await state.save();
+  expect(success).toBeTruthy();
+
+  fooField.setRaw("FOO!!!");
+
+  jest.runAllTimers();
+  await state.processPromise;
+
+  // now we've seen validation that includes non-live validations
+  expect(liveSeen).toEqual([true, false]);
+
+  // now we reset again to the before save status
+  state.resetSaveStatus();
+
+  fooField.setRaw("FOO???");
+
+  jest.runAllTimers();
+  await state.processPromise;
+  expect(liveSeen).toEqual([true, false, true]);
+});

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -589,3 +589,174 @@ test("process all configuration with state", async () => {
   expect(fooField.error).toBeUndefined();
   expect(barField.error).toEqual("bar error!");
 });
+
+test("process & live", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const liveSeen: boolean[] = [];
+
+  async function myProcess(
+    node: Instance<typeof M>,
+    path: string,
+    liveOnly: boolean
+  ) {
+    liveSeen.push(liveOnly);
+    return {
+      updates: [],
+      errorValidations: [],
+      warningValidations: []
+    };
+  }
+
+  async function mySave(node: Instance<typeof M>) {
+    return null;
+  }
+
+  const state = form.state(o, {
+    backend: {
+      process: myProcess,
+      save: mySave,
+      debounce: debounce
+    }
+  });
+
+  const fooField = state.field("foo");
+
+  // before a save, we only want the live fields
+  fooField.setRaw("FOO!");
+
+  jest.runAllTimers();
+  await state.processPromise;
+
+  expect(liveSeen).toEqual([true]);
+
+  // a successful save
+  const success = await state.save();
+  expect(success).toBeTruthy();
+
+  fooField.setRaw("FOO!!!");
+
+  jest.runAllTimers();
+  await state.processPromise;
+
+  // now we've seen validation that includes non-live validations
+  expect(liveSeen).toEqual([true, false]);
+});
+
+test("process & live save error", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const liveSeen: boolean[] = [];
+
+  async function myProcess(
+    node: Instance<typeof M>,
+    path: string,
+    liveOnly: boolean
+  ) {
+    liveSeen.push(liveOnly);
+    return {
+      updates: [],
+      errorValidations: [],
+      warningValidations: []
+    };
+  }
+
+  async function mySave(node: Instance<typeof M>) {
+    // this counts as an unsuccessful save
+    return {
+      updates: [],
+      errorValidations: [],
+      warningValidations: []
+    };
+  }
+
+  const state = form.state(o, {
+    backend: {
+      process: myProcess,
+      save: mySave,
+      debounce: debounce
+    }
+  });
+
+  const fooField = state.field("foo");
+
+  // before a save, we only want the live fields
+  fooField.setRaw("FOO!");
+
+  jest.runAllTimers();
+  await state.processPromise;
+
+  expect(liveSeen).toEqual([true]);
+
+  // an unsuccessful save
+  const success = await state.save();
+  expect(success).toBeFalsy();
+
+  fooField.setRaw("FOO!!!");
+
+  jest.runAllTimers();
+  await state.processPromise;
+
+  // now we've seen validation that includes non-live validations
+  expect(liveSeen).toEqual([true, false]);
+});
+
+test("processAll and liveOnly", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const liveSeen: boolean[] = [];
+
+  async function myProcessAll(node: Instance<typeof M>, liveOnly: boolean) {
+    liveSeen.push(liveOnly);
+    return {
+      updates: [],
+      errorValidations: [],
+      warningValidations: []
+    };
+  }
+
+  async function mySave(node: Instance<typeof M>) {
+    return null;
+  }
+
+  const state = form.state(o, {
+    backend: {
+      processAll: myProcessAll,
+      save: mySave,
+      debounce: debounce
+    }
+  });
+
+  await state.processAll();
+  expect(liveSeen).toEqual([true]);
+
+  await state.save();
+
+  await state.processAll();
+
+  expect(liveSeen).toEqual([true, false]);
+});

--- a/test/ignore.test.ts
+++ b/test/ignore.test.ts
@@ -341,3 +341,28 @@ test("ignoreGetError sub form accessor non-field external", async () => {
   const saveResult1 = await state.save();
   expect(saveResult1).toBeFalsy();
 });
+
+test("FormState can be saved without affecting save status", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  async function save(data: any) {
+    return null;
+  }
+
+  const state = form.state(o, {
+    backend: { save },
+    getError: accessor => (accessor.path === "/foo" ? "Wrong!" : undefined)
+  });
+
+  // now we save, ignoring save status
+  await state.save({ ignoreSaveStatus: true });
+  expect(state.saveStatus).toEqual("before");
+});


### PR DESCRIPTION
Introduce 'liveOnly' flag for `process' and 'processAll'. Introduce `ignoreSaveStatus` to create save behavior that doesn't affect validation status. Introduce `resetSaveStatus