### PR TITLE
Accessor interfaces

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,11 @@
 -   BREAKING CHANGE: if you define an error with `getError` and an external
     error is also set, that external error now takes precedence.
 
--   Introduce a new explicit IAccessor interface that is shared by all
-    accessors.
+-   Introduce a new explicit `IAccessor` interface that is shared by all
+    accessors. Also introduce `IFormAccessor`, which is shared by FormState,
+    RepeatingFormIndexedAccessor, and SubFormAccessor.
 
--   BREAKING CHANGE: Drop the old Accessor union type in favor of IAccessor.
+-   BREAKING CHANGE: Drop the old Accessor union type in favor of `IAccessor`.
 
 # 1.14.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 -   BREAKING CHANGE: if you define an error with `getError` and an external
     error is also set, that external error now takes precedence.
 
+-   Introduce a new explicit IAccessor interface that is shared by all
+    accessors.
+
+-   BREAKING CHANGE: Drop the old Accessor union type in favor of IAccessor.
+
 # 1.14.0
 
 -   The `process` and `processAll` functions for the backend now receive a third

--- a/src/accessor.ts
+++ b/src/accessor.ts
@@ -8,21 +8,9 @@ import {
   ValueType
 } from "./form";
 import { FieldAccessor } from "./field-accessor";
-import { FormAccessor } from "./form-accessor";
 import { RepeatingFormAccessor } from "./repeating-form-accessor";
-import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor";
 import { SubFormAccessor } from "./sub-form-accessor";
 import { GroupAccessor } from "./group-accessor";
-
-// group access is deliberately not in Accessor
-// as we never need to walk the group accessors to see
-// whether a form is valid
-export type Accessor =
-  | FormAccessor<any, any>
-  | FieldAccessor<any, any>
-  | RepeatingFormAccessor<any, any>
-  | RepeatingFormIndexedAccessor<any, any>
-  | SubFormAccessor<any, any>;
 
 export type FieldAccess<
   D extends FormDefinition<any>,

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -18,12 +18,12 @@ import {
 import { FormState } from "./state";
 import { FormAccessor } from "./form-accessor";
 import { currentValidationProps } from "./validation-props";
-import { Accessor } from "./accessor";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
 import { ExternalMessages } from "./validationMessages";
+import { IAccessor } from "./interfaces";
 
-export class FieldAccessor<R, V> {
+export class FieldAccessor<R, V> implements IAccessor {
   name: string;
 
   @observable
@@ -471,7 +471,11 @@ export class FieldAccessor<R, V> {
     return currentValidationProps(this);
   }
 
-  accessBySteps(steps: string[]): Accessor {
+  get accessors(): IAccessor[] {
+    return [];
+  }
+
+  accessBySteps(steps: string[]): IAccessor {
     throw new Error("Cannot step through field accessor");
   }
 }

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -1,7 +1,6 @@
 import { computed } from "mobx";
 import { FormDefinition, GroupDefinition } from "./form";
 import {
-  Accessor,
   FieldAccess,
   RepeatingFormAccess,
   SubFormAccess,
@@ -9,6 +8,7 @@ import {
 } from "./accessor";
 import { FormAccessor } from "./form-accessor";
 import { ValidateOptions } from "./validate-options";
+import { IAccessor } from "./interfaces";
 
 // a base class that delegates to a form accessor
 export abstract class FormAccessorBase<
@@ -55,11 +55,11 @@ export abstract class FormAccessorBase<
     return this.formAccessor.isValid;
   }
 
-  access(name: string): Accessor | undefined {
+  access(name: string): IAccessor | undefined {
     return this.formAccessor.access(name);
   }
 
-  accessBySteps(steps: string[]): Accessor | undefined {
+  accessBySteps(steps: string[]): IAccessor | undefined {
     if (steps.length === 0) {
       if (this.formAccessor.parent == null) {
         throw new Error("Unknown parent");
@@ -86,12 +86,12 @@ export abstract class FormAccessorBase<
   }
 
   @computed
-  get accessors(): Accessor[] {
+  get accessors(): IAccessor[] {
     return this.formAccessor.accessors;
   }
 
   @computed
-  get flatAccessors(): Accessor[] {
+  get flatAccessors(): IAccessor[] {
     return this.formAccessor.flatAccessors;
   }
 }

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -8,6 +8,7 @@ import {
 } from "./accessor";
 import { FormAccessor } from "./form-accessor";
 import { ValidateOptions } from "./validate-options";
+import { ExternalMessages } from "./validationMessages";
 import { IAccessor } from "./interfaces";
 
 // a base class that delegates to a form accessor
@@ -53,6 +54,45 @@ export abstract class FormAccessorBase<
   @computed
   get isValid(): boolean {
     return this.formAccessor.isValid;
+  }
+
+  @computed
+  get disabled(): boolean {
+    return this.formAccessor.disabled;
+  }
+
+  @computed
+  get hidden(): boolean {
+    return this.formAccessor.hidden;
+  }
+
+  @computed
+  get readOnly(): boolean {
+    return this.formAccessor.readOnly;
+  }
+
+  @computed
+  get inputAllowed(): boolean {
+    return this.formAccessor.inputAllowed;
+  }
+
+  @computed
+  get externalErrors(): ExternalMessages {
+    return this.formAccessor.externalErrors;
+  }
+
+  @computed
+  get externalWarnings(): ExternalMessages {
+    return this.formAccessor.externalWarnings;
+  }
+
+  @computed
+  get addMode(): boolean {
+    return this.formAccessor.addMode;
+  }
+
+  clear() {
+    return this.formAccessor.clear();
   }
 
   access(name: string): IAccessor | undefined {

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -23,12 +23,12 @@ import { GroupAccessor } from "./group-accessor";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
 import { ExternalMessages } from "./validationMessages";
-import { IAccessor } from "./interfaces";
+import { IAccessor, IFormAccessor } from "./interfaces";
 
 export class FormAccessor<
   D extends FormDefinition<any>,
   G extends GroupDefinition<D>
-> implements IAccessor {
+> implements IFormAccessor<D, G> {
   public keys: (keyof D)[];
   fieldAccessors: Map<keyof D, FieldAccessor<any, any>> = observable.map();
   repeatingFormAccessors: Map<

--- a/src/form-accessor.ts
+++ b/src/form-accessor.ts
@@ -10,7 +10,6 @@ import {
 } from "./form";
 import { FormState } from "./state";
 import {
-  Accessor,
   FieldAccess,
   RepeatingFormAccess,
   SubFormAccess,
@@ -24,11 +23,12 @@ import { GroupAccessor } from "./group-accessor";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
 import { ExternalMessages } from "./validationMessages";
+import { IAccessor } from "./interfaces";
 
 export class FormAccessor<
   D extends FormDefinition<any>,
   G extends GroupDefinition<D>
-> {
+> implements IAccessor {
   public keys: (keyof D)[];
   fieldAccessors: Map<keyof D, FieldAccessor<any, any>> = observable.map();
   repeatingFormAccessors: Map<
@@ -133,8 +133,8 @@ export class FormAccessor<
   }
 
   @computed
-  get accessors(): Accessor[] {
-    const result: Accessor[] = [];
+  get accessors(): IAccessor[] {
+    const result: IAccessor[] = [];
 
     this.keys.forEach(key => {
       const entry = this.definition[key];
@@ -150,8 +150,8 @@ export class FormAccessor<
   }
 
   @computed
-  get flatAccessors(): Accessor[] {
-    const result: Accessor[] = [];
+  get flatAccessors(): IAccessor[] {
+    const result: IAccessor[] = [];
     this.accessors.forEach(accessor => {
       if (accessor instanceof FieldAccessor) {
         result.push(accessor);
@@ -177,7 +177,7 @@ export class FormAccessor<
     return this.parent.addMode;
   }
 
-  access(name: string): Accessor | undefined {
+  access(name: string): IAccessor | undefined {
     if (!this.keys.includes(name)) {
       return undefined;
     }
@@ -198,7 +198,7 @@ export class FormAccessor<
     }
   }
 
-  accessBySteps(steps: string[]): Accessor | undefined {
+  accessBySteps(steps: string[]): IAccessor | undefined {
     if (steps.length === 0) {
       return this;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from "./form";
 export * from "./converter";
 export * from "./converters";
 export * from "./accessor";
+export * from "./interfaces";
 export * from "./field-accessor";
 export * from "./form-accessor";
 export * from "./repeating-form-accessor";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,26 @@
+import { ValidateOptions } from "./validate-options";
+import { ExternalMessages } from "./validationMessages";
+
+export interface IAccessor {
+  path: string;
+  error: string | undefined;
+  warning: string | undefined;
+  warningValue: string | undefined;
+  disabled: boolean;
+  hidden: boolean;
+  readOnly: boolean;
+  inputAllowed: boolean;
+  externalErrors: ExternalMessages;
+  externalWarnings: ExternalMessages;
+  value: any;
+
+  validate(options?: ValidateOptions): boolean;
+
+  isValid: boolean;
+
+  accessors: IAccessor[];
+  accessBySteps(steps: string[]): IAccessor | undefined;
+
+  dispose(): void;
+  clear(): void;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,6 +9,7 @@ import {
 
 export interface IAccessor {
   path: string;
+  fieldref: string;
   error: string | undefined;
   warning: string | undefined;
   warningValue: string | undefined;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,11 @@
 import { ValidateOptions } from "./validate-options";
 import { ExternalMessages } from "./validationMessages";
+import {
+  FieldAccess,
+  RepeatingFormAccess,
+  SubFormAccess,
+  GroupAccess
+} from "./accessor";
 
 export interface IAccessor {
   path: string;
@@ -24,4 +30,15 @@ export interface IAccessor {
 
   dispose(): void;
   clear(): void;
+}
+
+export interface IFormAccessor<D, G> extends IAccessor {
+  access(name: string): IAccessor | undefined;
+
+  field<K extends keyof D>(name: K): FieldAccess<D, K>;
+  repeatingForm<K extends keyof D>(name: K): RepeatingFormAccess<D, K>;
+  subForm<K extends keyof D>(name: K): SubFormAccess<D, K>;
+  group<K extends keyof G>(name: K): GroupAccess<D>;
+
+  flatAccessors: IAccessor[];
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,6 +13,7 @@ export interface IAccessor {
   externalErrors: ExternalMessages;
   externalWarnings: ExternalMessages;
   value: any;
+  addMode: boolean;
 
   validate(options?: ValidateOptions): boolean;
 

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -16,7 +16,10 @@ export class RepeatingFormAccessor<
   name: string;
 
   @observable
-  repeatingFormIndexedAccessors: Map<number, any> = observable.map();
+  repeatingFormIndexedAccessors: Map<
+    number,
+    RepeatingFormIndexedAccessor<D, G>
+  > = observable.map();
 
   externalErrors = new ExternalMessages();
   externalWarnings = new ExternalMessages();
@@ -128,13 +131,8 @@ export class RepeatingFormAccessor<
 
   @computed
   get accessors(): RepeatingFormIndexedAccessor<D, G>[] {
-    // we get the entries in this map, in order of index
-    const length = Array.from(this.repeatingFormIndexedAccessors.values())
-      .length;
-    const result = [];
-    for (let i = 0; i < length; i++) {
-      result.push(this.repeatingFormIndexedAccessors.get(i));
-    }
+    const result = Array.from(this.repeatingFormIndexedAccessors.values());
+    result.sort((first, second) => first.index - second.index);
     return result;
   }
 

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -2,17 +2,17 @@ import { observable, computed } from "mobx";
 import { applyPatch } from "mobx-state-tree";
 import { FormDefinition, RepeatingForm, GroupDefinition } from "./form";
 import { FormState } from "./state";
-import { Accessor } from "./accessor";
 import { RepeatingFormIndexedAccessor } from "./repeating-form-indexed-accessor";
 import { FormAccessor } from "./form-accessor";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
 import { ExternalMessages } from "./validationMessages";
+import { IAccessor } from "./interfaces";
 
 export class RepeatingFormAccessor<
   D extends FormDefinition<any>,
   G extends GroupDefinition<D>
-> {
+> implements IAccessor {
   name: string;
 
   @observable
@@ -139,8 +139,8 @@ export class RepeatingFormAccessor<
   }
 
   @computed
-  get flatAccessors(): Accessor[] {
-    const result: Accessor[] = [];
+  get flatAccessors(): IAccessor[] {
+    const result: IAccessor[] = [];
     this.accessors.forEach(accessor => {
       result.push(...accessor.flatAccessors);
       result.push(accessor);
@@ -148,7 +148,7 @@ export class RepeatingFormAccessor<
     return result;
   }
 
-  accessBySteps(steps: string[]): Accessor | undefined {
+  accessBySteps(steps: string[]): IAccessor | undefined {
     const [first, ...rest] = steps;
     const nr = parseInt(first, 10);
     if (isNaN(nr)) {

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -22,9 +22,6 @@ export class RepeatingFormIndexedAccessor<
   @observable
   _addMode: boolean = false;
 
-  externalErrors = new ExternalMessages();
-  externalWarnings = new ExternalMessages();
-
   constructor(
     public state: FormState<any, any, any>,
     public definition: D,

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -8,11 +8,12 @@ import { FormAccessorBase } from "./form-accessor-base";
 import { FormAccessor } from "./form-accessor";
 import { pathToFieldref } from "./utils";
 import { ExternalMessages } from "./validationMessages";
+import { IAccessor } from "./interfaces";
 
 export class RepeatingFormIndexedAccessor<
   D extends FormDefinition<any>,
   G extends GroupDefinition<D>
-> extends FormAccessorBase<D, G> {
+> extends FormAccessorBase<D, G> implements IAccessor {
   formAccessor: FormAccessor<D, G>;
 
   @observable

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -8,12 +8,12 @@ import { FormAccessorBase } from "./form-accessor-base";
 import { FormAccessor } from "./form-accessor";
 import { pathToFieldref } from "./utils";
 import { ExternalMessages } from "./validationMessages";
-import { IAccessor } from "./interfaces";
+import { IFormAccessor } from "./interfaces";
 
 export class RepeatingFormIndexedAccessor<
   D extends FormDefinition<any>,
   G extends GroupDefinition<D>
-> extends FormAccessorBase<D, G> implements IAccessor {
+> extends FormAccessorBase<D, G> implements IFormAccessor<D, G> {
   formAccessor: FormAccessor<D, G>;
 
   @observable

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -7,7 +7,6 @@ import { setAddModeDefaults } from "./addMode";
 import { FormAccessorBase } from "./form-accessor-base";
 import { FormAccessor } from "./form-accessor";
 import { pathToFieldref } from "./utils";
-import { ExternalMessages } from "./validationMessages";
 import { IFormAccessor } from "./interfaces";
 
 export class RepeatingFormIndexedAccessor<

--- a/src/state.ts
+++ b/src/state.ts
@@ -6,7 +6,6 @@ import {
   IAnyModelType,
   Instance
 } from "mobx-state-tree";
-import { Accessor } from "./accessor";
 import {
   Form,
   FormDefinition,
@@ -36,13 +35,14 @@ import {
 } from "./backend";
 import { setAddModeDefaults } from "./addMode";
 import { Validation } from "./validationMessages";
+import { IAccessor } from "./interfaces";
 
 export interface AccessorAllows {
-  (accessor: Accessor): boolean;
+  (accessor: IAccessor): boolean;
 }
 
 export interface ErrorOrWarning {
-  (accessor: Accessor): string | undefined;
+  (accessor: IAccessor): string | undefined;
 }
 
 export interface ExtraValidation {
@@ -455,12 +455,12 @@ export class FormState<
     return resolvePath(this.node, path);
   }
 
-  accessByPath(path: string): Accessor | undefined {
+  accessByPath(path: string): IAccessor | undefined {
     const steps = pathToSteps(path);
     return this.accessBySteps(steps);
   }
 
-  accessBySteps(steps: string[]): Accessor | undefined {
+  accessBySteps(steps: string[]): IAccessor | undefined {
     return this.formAccessor.accessBySteps(steps);
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -35,7 +35,7 @@ import {
 } from "./backend";
 import { setAddModeDefaults } from "./addMode";
 import { Validation } from "./validationMessages";
-import { IAccessor } from "./interfaces";
+import { IAccessor, IFormAccessor } from "./interfaces";
 
 export interface AccessorAllows {
   (accessor: IAccessor): boolean;
@@ -109,7 +109,7 @@ export class FormState<
   M extends IAnyModelType,
   D extends FormDefinition<M>,
   G extends GroupDefinition<D>
-> extends FormAccessorBase<D, G> {
+> extends FormAccessorBase<D, G> implements IFormAccessor<D, G> {
   @observable
   saveStatus: SaveStatusOptions = "before";
 

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -5,7 +5,6 @@ import { FormAccessor } from "./form-accessor";
 import { FormAccessorBase } from "./form-accessor-base";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
-import { ExternalMessages } from "./validationMessages";
 import { IFormAccessor } from "./interfaces";
 
 export class SubFormAccessor<
@@ -13,9 +12,6 @@ export class SubFormAccessor<
   G extends GroupDefinition<D>
 > extends FormAccessorBase<D, G> implements IFormAccessor<D, G> {
   formAccessor: FormAccessor<D, G>;
-
-  externalErrors = new ExternalMessages();
-  externalWarnings = new ExternalMessages();
 
   constructor(
     public state: FormState<any, any, any>,

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -6,11 +6,12 @@ import { FormAccessorBase } from "./form-accessor-base";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
 import { ExternalMessages } from "./validationMessages";
+import { IAccessor } from "./interfaces";
 
 export class SubFormAccessor<
   D extends FormDefinition<any>,
   G extends GroupDefinition<D>
-> extends FormAccessorBase<D, G> {
+> extends FormAccessorBase<D, G> implements IAccessor {
   formAccessor: FormAccessor<D, G>;
 
   externalErrors = new ExternalMessages();

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -6,12 +6,12 @@ import { FormAccessorBase } from "./form-accessor-base";
 import { ValidateOptions } from "./validate-options";
 import { pathToFieldref } from "./utils";
 import { ExternalMessages } from "./validationMessages";
-import { IAccessor } from "./interfaces";
+import { IFormAccessor } from "./interfaces";
 
 export class SubFormAccessor<
   D extends FormDefinition<any>,
   G extends GroupDefinition<D>
-> extends FormAccessorBase<D, G> implements IAccessor {
+> extends FormAccessorBase<D, G> implements IFormAccessor<D, G> {
   formAccessor: FormAccessor<D, G>;
 
   externalErrors = new ExternalMessages();


### PR DESCRIPTION
In an attempt to make the code easier to manage, introduce an explicit IAccessor and a IFormAccessor interface. This revealed a few places to modify to regularize the API.

My hope is that this helps to share more code between accessors in the future.