### PR TITLE
Don't show required validations after save.

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -378,14 +378,19 @@ export class FormState<
     }
     const isValid = this.validate({ ...extraOptions, ...options });
 
-    // if we ignored required, we need to re-validate to restore
-    // the required messages (if any)
-    // XXX does this make sense to move this to validate itself?
-    if (options != null && options.ignoreRequired) {
-      // we don't care about the answer, only about updating the messages
-      // in the UI
-      this.validate(extraOptions);
-    }
+    // XXX Either remove or uncomment after making a decision.
+    // We're testing if we want to ignore all validation messages when saving.
+    // This means the messages that were already there will disappear when
+    // saving.
+
+    // // if we ignored required, we need to re-validate to restore
+    // // the required messages (if any)
+    // // XXX does this make sense to move this to validate itself?
+    // if (options != null && options.ignoreRequired) {
+    //   // we don't care about the answer, only about updating the messages
+    //   // in the UI
+    //   this.validate(extraOptions);
+    // }
 
     if (!options.ignoreSaveStatus) {
       this.setSaveStatus("rightAfter");

--- a/test/ignore.test.ts
+++ b/test/ignore.test.ts
@@ -89,7 +89,7 @@ test("FormState can be saved ignoring required", async () => {
   // we still see the message, even though save succeeded
   // XXX is this really the desired behavior? don't we want
   // the required error until we save without ignoreRequired?
-  expect(field.error).toEqual("Required");
+  expect(field.error).toEqual(undefined);
   // but saving actually succeeded
   expect(o.foo).toEqual("");
   expect(saveResult).toBeTruthy();


### PR DESCRIPTION
At the request of our product owner, we don't want to show validations anymore after saving. This means they disappear after pressing save.