### PR TITLE
Warningcheck in all accessors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 
 -   BREAKING CHANGE: Drop the old Accessor union type in favor of `IAccessor`.
 
+-   Add an `isWarningFree` value to GroupAccessors.
+
 # 1.14.0
 
 -   The `process` and `processAll` functions for the backend now receive a third

--- a/README.md
+++ b/README.md
@@ -297,8 +297,8 @@ mstform defines a bunch of accessors:
 
 -   `GroupAccessor`. You define this in a second argument on forms. You can
     access it via the `group()` method on any form accessor. This is a special
-    kind of accessor that only implements an `isValid` method. It's a way to
-    aggregate validation results from other accessors.
+    kind of accessor that only implements the `isValid` and `isWarningFree` methods.
+    It's a way to aggregate validation results from other accessors.
 
 -   Finally there is the `FormState` itself, which is the accessor at the root of
     all things. You get it with `form.state()`.
@@ -1341,12 +1341,15 @@ Here we define two groups, `one` and `two`. Group `one` is valid only if `a`
 and `b` are valid. Group `two` is valid only if `c` is valid.
 
 You can access a group on the state or form accessor and check its `isValid`
-property:
+or `isWarningFree` property:
 
 ```js
 const first = state.group("first");
 if (first.isValid) {
     // only executed if a and b are valid
+}
+if (first.isWarningFree) {
+    // only executed if none of the group members have warnings
 }
 ```
 

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -13,16 +13,25 @@ export class GroupAccessor<D extends FormDefinition<any>> {
 
   @computed
   get isValid(): boolean {
+    return this.hasFeedback(this.isValidForNames.bind(this));
+  }
+
+  @computed
+  get isWarningFree(): boolean {
+    return this.hasFeedback(this.isWarningFreeForNames.bind(this));
+  }
+
+  hasFeedback(feedbackFunc: Function): boolean {
     const include = this.group.options.include;
     const exclude = this.group.options.exclude;
     if (include != null && exclude != null) {
       throw new Error("Cannot include and exclude fields at the same time.");
     }
     if (include != null) {
-      return this.isValidForNames(include);
+      return feedbackFunc(include);
     }
     if (exclude != null) {
-      return this.isValidForNames(this.notExcluded(exclude));
+      return feedbackFunc(this.notExcluded(exclude));
     }
     throw new Error("Must include or exclude some fields");
   }
@@ -39,6 +48,16 @@ export class GroupAccessor<D extends FormDefinition<any>> {
         return true;
       }
       return accessor.isValid;
+    });
+  }
+
+  isWarningFreeForNames(names: (keyof D)[]): boolean {
+    return names.every(key => {
+      const accessor = this.parent.access(key as string);
+      if (accessor == null) {
+        return true;
+      }
+      return accessor.isWarningFree;
     });
   }
 }

--- a/test/warning.test.ts
+++ b/test/warning.test.ts
@@ -36,8 +36,10 @@ test("a simple warning", async () => {
   const barField = state.field("bar");
 
   expect(fooField.raw).toEqual("FOO");
+  expect(fooField.isWarningFree).toBeFalsy();
   expect(fooField.warning).toEqual("Please reconsider");
   expect(barField.raw).toEqual("BAR");
+  expect(barField.isWarningFree).toBeTruthy();
   expect(barField.warning).toBeUndefined();
   expect(state.isWarningFree).toBeFalsy();
 
@@ -151,6 +153,7 @@ test("both errors and warnings", () => {
   expect(fooField.raw).toEqual("FOO");
   expect(fooField.error).toEqual("Wrong");
   expect(fooField.warning).toEqual("Please reconsider");
+  expect(fooField.isWarningFree).toBeFalsy();
   expect(state.isWarningFree).toBeFalsy();
 });
 
@@ -180,9 +183,12 @@ test("warning in repeating form", () => {
   const barField2 = forms.index(1).field("bar");
 
   expect(barField1.raw).toEqual("correct");
+  expect(barField1.isWarningFree).toBeTruthy();
   expect(barField1.warning).toBeUndefined();
   expect(barField2.raw).toEqual("incorrect");
+  expect(barField2.isWarningFree).toBeFalsy();
   expect(barField2.warning).toEqual("Please reconsider");
+  expect(forms.isWarningFree).toBeFalsy();
   expect(state.isWarningFree).toBeFalsy();
 });
 
@@ -211,11 +217,15 @@ test("warning in subform field", () => {
   });
 
   const fooField = state.field("foo");
+  const subForm = state.subForm("sub");
   const barField = state.subForm("sub").field("bar");
   expect(fooField.raw).toEqual("FOO");
+  expect(fooField.isWarningFree).toBeTruthy();
   expect(fooField.warning).toBeUndefined();
   expect(barField.raw).toEqual("BAR");
+  expect(barField.isWarningFree).toBeFalsy();
   expect(barField.warning).toEqual("Please reconsider");
+  expect(subForm.isWarningFree).toBeFalsy();
   expect(state.isWarningFree).toBeFalsy();
 });
 
@@ -286,12 +296,14 @@ test("warning on repeating form", () => {
 
   const repeatingForms = state.repeatingForm("foo");
 
+  expect(repeatingForms.isWarningFree).toBeFalsy();
   expect(repeatingForms.warning).toEqual("Empty");
   expect(state.isWarningFree).toBeFalsy();
 
   repeatingForms.push({ bar: "BAR" });
   state.validate();
 
+  expect(repeatingForms.isWarningFree).toBeTruthy();
   expect(repeatingForms.warning).toBeUndefined();
   expect(state.isWarningFree).toBeTruthy();
 });
@@ -354,8 +366,11 @@ test("warning on indexed repeating form", () => {
   const fooForm1 = forms.index(0);
   const fooForm2 = forms.index(1);
 
+  expect(fooForm1.isWarningFree).toBeTruthy();
   expect(fooForm1.warning).toBeUndefined();
+  expect(fooForm2.isWarningFree).toBeFalsy();
   expect(fooForm2.warning).toEqual("Warning");
+  expect(forms.isWarningFree).toBeFalsy();
   expect(state.isWarningFree).toBeFalsy();
 });
 
@@ -419,6 +434,7 @@ test("warning on subform", () => {
   const subform = state.subForm("sub");
 
   expect(subform.warning).toEqual("Warning");
+  expect(subform.isWarningFree).toBeFalsy();
   expect(state.isWarningFree).toBeFalsy();
 });
 


### PR DESCRIPTION
Added an `isWarningFree` value to the GroupAccessor. Now we can request from a group whether or not there are warnings present in it.