### PR TITLE
Source load arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,20 @@
+# 1.23.0
+
+-   BREAKING CHANGE: Change the way sources work: `load` now takes the query as
+    the first argument, and the timestamp as the second argument. If you leave
+    out the timestamp, it generates the current timestamp. If you leave out the
+    query it falls back on an empty `{}`.
+
+    For `values` you can also leave out the first argument.
+
+    This makes the behavior of source more consistent with that of references.
+
+-   BREAKING CHANGE: instead of passing `container` to the source (which then
+    should have an `entryMap` property), you pass through `types.map` property
+    directly. `entryMapName` is not needed anymore so has been removed. Sources
+    now know about their types better -- unfortunately `references` on field
+    accessor still lose this information but this may be a future improvement.
+
 # 1.22.0
 
 -   The string converter can now take the option `maxLength`, which validates

--- a/README.md
+++ b/README.md
@@ -1559,7 +1559,19 @@ way to load users::
 import { Source } from "mstform";
 
 const userSource = new Source({
-    container: root.userContainer,
+    entryMap: root.userContainer.entryMap,
+    load: loadUsers
+});
+```
+
+Note that you can also make `entryMap` a function that returns the
+`entryMap`:
+
+```js
+import { Source } from "mstform";
+
+const userSource = new Source({
+    entryMap: () => root.userContainer.entryMap,
     load: loadUsers
 });
 ```
@@ -1592,10 +1604,10 @@ autocomplete, we must load the references:
 const state = this.formState;
 const user = state.field("user");
 
-await user.references.load();
+await user.references.load({{}});
 ```
 
-`references.load()` can contain an object argument -- these are additional
+`references.load()` contains an query argument -- these are additional
 search parameters to pass through `loadUser`, such as what the user typed in
 an autocomplete field.
 
@@ -1606,15 +1618,15 @@ Once references are loaded, we can access them in the UI (inside a React
 const state = this.formState;
 const user = state.field("user");
 
-const values = user.references.values();
+const values = user.references.values({});
 // display values somewhere
 ```
 
 The source caches search requests, so that any future `references.load()` with
-the same parameters resolve immediately without even hitting the backend. For
-this reason, the search query accepted by `load` must be either JSON
-serializable or alternatively you can provide a `keyForQuery` function to
-`Source` which turns the search parameters into a unique cache key.
+the same query resolve immediately without even hitting the backend. For this
+reason, the search query accepted by `load` must be either JSON serializable or
+alternatively you can provide a `keyForQuery` function to `Source` which turns
+the search parameters into a unique cache key.
 
 You can also make a field depend on another. Let's imagine that we have
 a way to look for users that are friends of a user:
@@ -1665,6 +1677,16 @@ other fields. If you want to enable this you can call `autoLoadReaction()` on
 `references`. If you don't call it (the default) then you are responsible for
 this yourself. This is useful for autocomplete widgets which only reload when
 the user interacts with them.
+
+You can configure sources to use a defaultQuery if invoked without
+arguments.
+
+You can call `load` and `values` on sources directly too. If you don't
+pass the query argument, it defaults to `{}` like for references.
+
+You can call `clear()` on the source to remove _everything_ in it -- you should
+only do this if you have nothing pointing to entries in its underlying
+`entryMap`, or if all references are mobx-state-tree `safeReference`.
 
 Note: mstform does not yet not implement any cache eviction facilities, either
 from the container or from the search results.

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -34,7 +34,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
 
   _disposer: IReactionDisposer | undefined;
 
-  references: IReferences<any, any>;
+  references: IReferences<any, any, any>;
 
   constructor(
     public state: FormState<any, any, any>,

--- a/src/form.ts
+++ b/src/form.ts
@@ -86,7 +86,7 @@ export interface AccessorDependentQuery<DQ> {
 }
 
 export interface ReferenceOptions<SQ, DQ> {
-  source: Source<SQ & DQ>;
+  source: Source<any, SQ & DQ>;
   dependentQuery?: AccessorDependentQuery<DQ>;
 }
 

--- a/src/references.ts
+++ b/src/references.ts
@@ -23,7 +23,7 @@ export interface DependentQuery<DQ> {
 export class References<SQ extends Query, DQ extends Query>
   implements IReferences<SQ, DQ> {
   constructor(
-    public source: ISource<any>,
+    public source: ISource<any, SQ & DQ>,
     public dependentQuery: DependentQuery<DQ> = () => ({} as DQ)
   ) {}
 

--- a/src/references.ts
+++ b/src/references.ts
@@ -52,7 +52,7 @@ export class References<SQ extends Query, DQ extends Query>
     timestamp: number,
     searchQuery?: SQ
   ): Promise<Instance<IAnyModelType>[]> {
-    return this.source.load(timestamp, this.getFullQuery(searchQuery));
+    return this.source.load(this.getFullQuery(searchQuery), timestamp);
   }
 
   async load(searchQuery?: SQ): Promise<Instance<IAnyModelType>[]> {

--- a/src/references.ts
+++ b/src/references.ts
@@ -1,8 +1,6 @@
 import { reaction, IReactionDisposer } from "mobx";
 import { Instance, IAnyModelType } from "mobx-state-tree";
-import { ISource } from "./source";
-
-export type Query = {};
+import { ISource, Query } from "./source";
 
 export interface IReferences<
   T extends IAnyModelType,

--- a/src/references.ts
+++ b/src/references.ts
@@ -4,15 +4,19 @@ import { ISource } from "./source";
 
 export type Query = {};
 
-export interface IReferences<SQ extends Query, DQ extends Query> {
+export interface IReferences<
+  T extends IAnyModelType,
+  SQ extends Query,
+  DQ extends Query
+> {
   autoLoadReaction(): IReactionDisposer;
-  load(searchQuery?: SQ): Promise<Instance<IAnyModelType>[]>;
+  load(searchQuery?: SQ): Promise<Instance<T>[]>;
   loadWithTimestamp(
     timestamp: number,
     searchQuery?: SQ
-  ): Promise<Instance<IAnyModelType>[]>;
-  values(searchQuery?: SQ): Instance<IAnyModelType>[] | undefined;
-  getById(id: any): Instance<IAnyModelType>;
+  ): Promise<Instance<T>[]>;
+  values(searchQuery?: SQ): Instance<T>[] | undefined;
+  getById(id: any): Instance<T> | undefined;
   isEnabled(): boolean;
 }
 
@@ -20,10 +24,13 @@ export interface DependentQuery<DQ> {
   (): DQ;
 }
 
-export class References<SQ extends Query, DQ extends Query>
-  implements IReferences<SQ, DQ> {
+export class References<
+  T extends IAnyModelType,
+  SQ extends Query,
+  DQ extends Query
+> implements IReferences<T, SQ, DQ> {
   constructor(
-    public source: ISource<any, SQ & DQ>,
+    public source: ISource<T, SQ & DQ>,
     public dependentQuery: DependentQuery<DQ> = () => ({} as DQ)
   ) {}
 
@@ -51,19 +58,19 @@ export class References<SQ extends Query, DQ extends Query>
   async loadWithTimestamp(
     timestamp: number,
     searchQuery?: SQ
-  ): Promise<Instance<IAnyModelType>[]> {
+  ): Promise<Instance<T>[]> {
     return this.source.load(this.getFullQuery(searchQuery), timestamp);
   }
 
-  async load(searchQuery?: SQ): Promise<Instance<IAnyModelType>[]> {
+  async load(searchQuery?: SQ): Promise<Instance<T>[]> {
     return this.loadWithTimestamp(new Date().getTime(), searchQuery);
   }
 
-  values(searchQuery?: SQ): Instance<IAnyModelType>[] | undefined {
+  values(searchQuery?: SQ): Instance<T>[] | undefined {
     return this.source.values(this.getFullQuery(searchQuery));
   }
 
-  getById(id: any): Instance<IAnyModelType> {
+  getById(id: any): Instance<T> | undefined {
     return this.source.getById(id);
   }
 
@@ -73,7 +80,7 @@ export class References<SQ extends Query, DQ extends Query>
 }
 
 export class NoReferences<SQ extends Query, DQ extends Query>
-  implements IReferences<SQ, DQ> {
+  implements IReferences<any, SQ, DQ> {
   autoLoadReaction(): IReactionDisposer {
     throw new Error(`No references defined`);
   }

--- a/src/source.ts
+++ b/src/source.ts
@@ -6,12 +6,9 @@ import {
   IAnyModelType
 } from "mobx-state-tree";
 
-export interface ISource<T extends IAnyModelType> {
-  load(
-    query?: { [key: string]: any },
-    timestamp?: number
-  ): Promise<Instance<T>[]>;
-  values(query?: { [key: string]: any }): Instance<T>[] | undefined;
+export interface ISource<T extends IAnyModelType, Q> {
+  load(query?: Q, timestamp?: number): Promise<Instance<T>[]>;
+  values(query?: Q): Instance<T>[] | undefined;
   getById(id: any): Instance<T>;
 }
 
@@ -32,7 +29,7 @@ interface CacheEntry {
   values: Instance<IAnyModelType>[];
 }
 
-export class Source<Q> implements ISource<any> {
+export class Source<Q> implements ISource<any, Q> {
   _container: any;
   _load: Load<Q>;
   _getId: GetId;

--- a/src/source.ts
+++ b/src/source.ts
@@ -9,8 +9,8 @@ import {
 // XXX need to make things implement this type, and export it to the outside world
 export interface ISource<T extends IAnyModelType> {
   load(
-    timestamp: number,
-    query: { [key: string]: any }
+    query: { [key: string]: any },
+    timestamp: number
   ): Promise<Instance<T>[]>;
   values(query: { [key: string]: any }): Instance<T>[] | undefined;
   getById(id: any): Instance<T>;
@@ -117,7 +117,7 @@ export class Source<Q> implements ISource<any> {
     this._cache.set(key, { values: values, timestamp: timestamp });
   }
 
-  async load(timestamp: number, q: Q): Promise<Instance<IAnyModelType>[]> {
+  async load(q: Q, timestamp: number): Promise<Instance<IAnyModelType>[]> {
     const key = this._keyForQuery(q);
     const result = this._cache.get(key);
     if (

--- a/src/source.ts
+++ b/src/source.ts
@@ -6,11 +6,10 @@ import {
   IAnyModelType
 } from "mobx-state-tree";
 
-// XXX need to make things implement this type, and export it to the outside world
 export interface ISource<T extends IAnyModelType> {
   load(
     query: { [key: string]: any },
-    timestamp: number
+    timestamp?: number
   ): Promise<Instance<T>[]>;
   values(query: { [key: string]: any }): Instance<T>[] | undefined;
   getById(id: any): Instance<T>;
@@ -60,7 +59,6 @@ export class Source<Q> implements ISource<any> {
     cacheDuration?: number;
     mapPropertyName?: string;
   }) {
-    // XXX make it to we can get the container dynamically
     this._container = container;
     this._load = load;
     if (getId == null) {
@@ -117,7 +115,10 @@ export class Source<Q> implements ISource<any> {
     this._cache.set(key, { values: values, timestamp: timestamp });
   }
 
-  async load(q: Q, timestamp: number): Promise<Instance<IAnyModelType>[]> {
+  async load(
+    q: Q,
+    timestamp: number = new Date().getTime()
+  ): Promise<Instance<IAnyModelType>[]> {
     const key = this._keyForQuery(q);
     const result = this._cache.get(key);
     if (

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -1,5 +1,5 @@
 import { configure } from "mobx";
-import { types, getSnapshot } from "mobx-state-tree";
+import { types, getSnapshot, SnapshotIn } from "mobx-state-tree";
 import { Source, Form, converters, Field } from "../src";
 import { resolveReactions } from "./util";
 
@@ -14,10 +14,17 @@ function refSnapshots(refs: any[] | undefined): any[] {
 }
 
 test("source", async () => {
-  const Item = types.model("Item", {
-    id: types.identifierNumber,
-    text: types.string
-  });
+  const Item = types
+    .model("Item", {
+      id: types.identifierNumber,
+      text: types.string,
+      feature: types.string
+    })
+    .views(self => ({
+      get displayText() {
+        return "Display " + self.text;
+      }
+    }));
 
   const Container = types.model("Container", {
     entryMap: types.map(Item)
@@ -38,17 +45,26 @@ test("source", async () => {
     return data.filter(entry => entry.feature === feature);
   };
 
-  const source = new Source({ container, load, cacheDuration: 2 });
+  const source = new Source({
+    entryMap: container.entryMap,
+    load,
+    cacheDuration: 2
+  });
 
   await source.load({ feature: "x" }, 0);
-  expect(source.getById(1)).toEqual({ id: 1, text: "A" });
+  expect(source.getById(1)).toEqual({ id: 1, text: "A", feature: "x" });
 
   const values = source.values({ feature: "x" });
   expect(values).not.toBeUndefined();
+  if (values == null) {
+    throw new Error("shouldn't happen");
+  }
   expect(refSnapshots(values)).toEqual([
-    { id: 1, text: "A" },
-    { id: 2, text: "B" }
+    { id: 1, text: "A", feature: "x" },
+    { id: 2, text: "B", feature: "x" }
   ]);
+
+  expect(values[0].displayText).toEqual("Display A");
   expect(loadHit).toEqual(["x"]);
 
   // when we try to reload with the same feature, we don't get a hit for load
@@ -59,8 +75,8 @@ test("source", async () => {
   const values2 = source.values({ feature: "x" });
   expect(values2).not.toBeUndefined();
   expect(refSnapshots(values2)).toEqual([
-    { id: 1, text: "A" },
-    { id: 2, text: "B" }
+    { id: 1, text: "A", feature: "x" },
+    { id: 2, text: "B", feature: "x" }
   ]);
 
   // when the cache duration has expired we expect another load.
@@ -94,7 +110,7 @@ test("source container function", async () => {
   };
 
   const source = new Source({
-    container: () => container,
+    entryMap: () => container.entryMap,
     load,
     cacheDuration: 2
   });
@@ -191,8 +207,8 @@ describe("source accessor in fields", () => {
     const containerA = r.containerA;
     const containerB = r.containerB;
 
-    const sourceA = new Source({ container: containerA, load: loadA });
-    const sourceB = new Source({ container: containerB, load: loadB });
+    const sourceA = new Source({ entryMap: containerA.entryMap, load: loadA });
+    const sourceB = new Source({ entryMap: containerB.entryMap, load: loadB });
 
     const form = new Form(M, {
       a: new Field(converters.maybe(converters.model(ItemA)), {
@@ -272,8 +288,8 @@ describe("source accessor in fields", () => {
     const containerA = r.containerA;
     const containerB = r.containerB;
 
-    const sourceA = new Source({ container: containerA, load: loadA });
-    const sourceB = new Source({ container: containerB, load: loadB });
+    const sourceA = new Source({ entryMap: containerA.entryMap, load: loadA });
+    const sourceB = new Source({ entryMap: containerB.entryMap, load: loadB });
 
     const form = new Form(M, {
       a: new Field(converters.maybe(converters.model(ItemA)), {
@@ -367,7 +383,8 @@ describe("source accessor in fields", () => {
 test("source clear", async () => {
   const Item = types.model("Item", {
     id: types.identifierNumber,
-    text: types.string
+    text: types.string,
+    feature: types.string
   });
 
   const Container = types.model("Container", {
@@ -376,7 +393,7 @@ test("source clear", async () => {
 
   const container = Container.create({ entryMap: {} });
 
-  const data = [
+  const data: SnapshotIn<typeof Item>[] = [
     { id: 1, text: "A", feature: "x" },
     { id: 2, text: "B", feature: "x" },
     { id: 3, text: "C", feature: "y" }
@@ -386,28 +403,38 @@ test("source clear", async () => {
     return data;
   };
 
-  const source = new Source({ container, load, cacheDuration: 2 });
+  const source = new Source<typeof Item, any>({
+    entryMap: container.entryMap,
+    load,
+    cacheDuration: 2
+  });
 
   await source.load({}, 0);
-  expect(source.getById(1)).toEqual({ id: 1, text: "A" });
+  expect(source.getById(1)).toEqual({ id: 1, text: "A", feature: "x" });
 
   const values = source.values({});
+  expect(values).toBeDefined();
+  if (values == null) {
+    throw new Error("This shouldn't happen");
+  }
+
   expect(values).not.toBeUndefined();
   expect(refSnapshots(values)).toEqual([
-    { id: 1, text: "A" },
-    { id: 2, text: "B" },
-    { id: 3, text: "C" }
+    { id: 1, text: "A", feature: "x" },
+    { id: 2, text: "B", feature: "x" },
+    { id: 3, text: "C", feature: "y" }
   ]);
 
   source.clear();
-  expect(Array.from(source.items.keys()).length).toBe(0);
+  expect(Array.from(source.entryMap.keys()).length).toBe(0);
   expect(source.values({})).toBeUndefined();
 });
 
 test("source default timestamp", async () => {
   const Item = types.model("Item", {
     id: types.identifierNumber,
-    text: types.string
+    text: types.string,
+    feature: types.string
   });
 
   const Container = types.model("Container", {
@@ -416,7 +443,7 @@ test("source default timestamp", async () => {
 
   const container = Container.create({ entryMap: {} });
 
-  const data = [
+  const data: SnapshotIn<typeof Item>[] = [
     { id: 1, text: "A", feature: "x" },
     { id: 2, text: "B", feature: "x" },
     { id: 3, text: "C", feature: "y" }
@@ -429,7 +456,11 @@ test("source default timestamp", async () => {
     return data.filter(entry => entry.feature === feature);
   };
 
-  const source = new Source({ container, load, cacheDuration: 2 });
+  const source = new Source({
+    entryMap: container.entryMap,
+    load,
+    cacheDuration: 2
+  });
 
   await source.load({ feature: "x" });
   expect(loadHit).toEqual(["x"]);
@@ -442,7 +473,8 @@ test("source default timestamp", async () => {
 test("source default query", async () => {
   const Item = types.model("Item", {
     id: types.identifierNumber,
-    text: types.string
+    text: types.string,
+    feature: types.string
   });
 
   const Container = types.model("Container", {
@@ -451,7 +483,7 @@ test("source default query", async () => {
 
   const container = Container.create({ entryMap: {} });
 
-  const data = [
+  const data: SnapshotIn<typeof Item>[] = [
     { id: 1, text: "A", feature: "x" },
     { id: 2, text: "B", feature: "x" },
     { id: 3, text: "C", feature: "y" }
@@ -465,7 +497,7 @@ test("source default query", async () => {
   };
 
   const source = new Source({
-    container,
+    entryMap: container.entryMap,
     load,
     cacheDuration: 2,
     defaultQuery: () => ({})
@@ -482,7 +514,8 @@ test("source default query", async () => {
 test("source no default query", async () => {
   const Item = types.model("Item", {
     id: types.identifierNumber,
-    text: types.string
+    text: types.string,
+    feature: types.string
   });
 
   const Container = types.model("Container", {
@@ -491,7 +524,7 @@ test("source no default query", async () => {
 
   const container = Container.create({ entryMap: {} });
 
-  const data = [
+  const data: SnapshotIn<typeof Item>[] = [
     { id: 1, text: "A", feature: "x" },
     { id: 2, text: "B", feature: "x" },
     { id: 3, text: "C", feature: "y" }
@@ -504,6 +537,10 @@ test("source no default query", async () => {
     return data.filter(entry => entry.feature === feature);
   };
 
-  const source = new Source({ container, load, cacheDuration: 2 });
+  const source = new Source({
+    entryMap: container.entryMap,
+    load,
+    cacheDuration: 2
+  });
   expect(source.load()).rejects.toThrowError(Error);
 });

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -1,5 +1,5 @@
 import { configure } from "mobx";
-import { types, getSnapshot, SnapshotIn } from "mobx-state-tree";
+import { types, getSnapshot } from "mobx-state-tree";
 import { Source, Form, converters, Field } from "../src";
 import { resolveReactions } from "./util";
 
@@ -393,7 +393,7 @@ test("source clear", async () => {
 
   const container = Container.create({ entryMap: {} });
 
-  const data: SnapshotIn<typeof Item>[] = [
+  const data = [
     { id: 1, text: "A", feature: "x" },
     { id: 2, text: "B", feature: "x" },
     { id: 3, text: "C", feature: "y" }
@@ -443,7 +443,7 @@ test("source default timestamp", async () => {
 
   const container = Container.create({ entryMap: {} });
 
-  const data: SnapshotIn<typeof Item>[] = [
+  const data = [
     { id: 1, text: "A", feature: "x" },
     { id: 2, text: "B", feature: "x" },
     { id: 3, text: "C", feature: "y" }
@@ -483,7 +483,7 @@ test("source default query", async () => {
 
   const container = Container.create({ entryMap: {} });
 
-  const data: SnapshotIn<typeof Item>[] = [
+  const data = [
     { id: 1, text: "A", feature: "x" },
     { id: 2, text: "B", feature: "x" },
     { id: 3, text: "C", feature: "y" }
@@ -524,7 +524,7 @@ test("source no default query", async () => {
 
   const container = Container.create({ entryMap: {} });
 
-  const data: SnapshotIn<typeof Item>[] = [
+  const data = [
     { id: 1, text: "A", feature: "x" },
     { id: 2, text: "B", feature: "x" },
     { id: 3, text: "C", feature: "y" }

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -40,7 +40,7 @@ test("source", async () => {
 
   const source = new Source({ container, load, cacheDuration: 2 });
 
-  await source.load(0, { feature: "x" });
+  await source.load({ feature: "x" }, 0);
   expect(source.getById(1)).toEqual({ id: 1, text: "A" });
 
   const values = source.values({ feature: "x" });
@@ -52,7 +52,7 @@ test("source", async () => {
   expect(loadHit).toEqual(["x"]);
 
   // when we try to reload with the same feature, we don't get a hit for load
-  await source.load(0, { feature: "x" });
+  await source.load({ feature: "x" }, 0);
   expect(loadHit).toEqual(["x"]);
 
   // and we still get the same results
@@ -64,7 +64,7 @@ test("source", async () => {
   ]);
 
   // when the cache duration has expired we expect another load.
-  await source.load(3 * 1000, { feature: "x" });
+  await source.load({ feature: "x" }, 3 * 1000);
   expect(loadHit).toEqual(["x", "x"]);
 });
 
@@ -99,7 +99,7 @@ test("source container function", async () => {
     cacheDuration: 2
   });
 
-  await source.load(0, { feature: "x" });
+  await source.load({ feature: "x" }, 0);
   expect(source.getById(1)).toEqual({ id: 1, text: "A" });
 
   const values = source.values({ feature: "x" });
@@ -111,7 +111,7 @@ test("source container function", async () => {
   expect(loadHit).toEqual(["x"]);
 
   // when we try to reload with the same feature, we don't get a hit for load
-  await source.load(0, { feature: "x" });
+  await source.load({ feature: "x" }, 0);
   expect(loadHit).toEqual(["x"]);
 
   // and we still get the same results
@@ -123,7 +123,7 @@ test("source container function", async () => {
   ]);
 
   // when the cache duration has expired we expect another load.
-  await source.load(3 * 1000, { feature: "x" });
+  await source.load({ feature: "x" }, 3 * 1000);
   expect(loadHit).toEqual(["x", "x"]);
 });
 
@@ -388,7 +388,7 @@ test("source clear", async () => {
 
   const source = new Source({ container, load, cacheDuration: 2 });
 
-  await source.load(0, {});
+  await source.load({}, 0);
   expect(source.getById(1)).toEqual({ id: 1, text: "A" });
 
   const values = source.values({});

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -499,8 +499,7 @@ test("source default query", async () => {
   const source = new Source({
     entryMap: container.entryMap,
     load,
-    cacheDuration: 2,
-    defaultQuery: () => ({})
+    cacheDuration: 2
   });
 
   await source.load();
@@ -509,38 +508,4 @@ test("source default query", async () => {
   // we should still get it from the cache, as timestamp was sent
   // implicitly.
   expect(loadHit).toEqual([undefined]);
-});
-
-test("source no default query", async () => {
-  const Item = types.model("Item", {
-    id: types.identifierNumber,
-    text: types.string,
-    feature: types.string
-  });
-
-  const Container = types.model("Container", {
-    entryMap: types.map(Item)
-  });
-
-  const container = Container.create({ entryMap: {} });
-
-  const data = [
-    { id: 1, text: "A", feature: "x" },
-    { id: 2, text: "B", feature: "x" },
-    { id: 3, text: "C", feature: "y" }
-  ];
-
-  const loadHit: (string | undefined)[] = [];
-
-  const load = async ({ feature }: { feature?: string }) => {
-    loadHit.push(feature);
-    return data.filter(entry => entry.feature === feature);
-  };
-
-  const source = new Source({
-    entryMap: container.entryMap,
-    load,
-    cacheDuration: 2
-  });
-  expect(source.load()).rejects.toThrowError(Error);
 });

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -438,3 +438,72 @@ test("source default timestamp", async () => {
   // implicitly.
   expect(loadHit).toEqual(["x"]);
 });
+
+test("source default query", async () => {
+  const Item = types.model("Item", {
+    id: types.identifierNumber,
+    text: types.string
+  });
+
+  const Container = types.model("Container", {
+    entryMap: types.map(Item)
+  });
+
+  const container = Container.create({ entryMap: {} });
+
+  const data = [
+    { id: 1, text: "A", feature: "x" },
+    { id: 2, text: "B", feature: "x" },
+    { id: 3, text: "C", feature: "y" }
+  ];
+
+  const loadHit: (string | undefined)[] = [];
+
+  const load = async ({ feature }: { feature?: string }) => {
+    loadHit.push(feature);
+    return data.filter(entry => entry.feature === feature);
+  };
+
+  const source = new Source({
+    container,
+    load,
+    cacheDuration: 2,
+    defaultQuery: () => ({})
+  });
+
+  await source.load();
+  expect(loadHit).toEqual([undefined]);
+  await source.load();
+  // we should still get it from the cache, as timestamp was sent
+  // implicitly.
+  expect(loadHit).toEqual([undefined]);
+});
+
+test("source no default query", async () => {
+  const Item = types.model("Item", {
+    id: types.identifierNumber,
+    text: types.string
+  });
+
+  const Container = types.model("Container", {
+    entryMap: types.map(Item)
+  });
+
+  const container = Container.create({ entryMap: {} });
+
+  const data = [
+    { id: 1, text: "A", feature: "x" },
+    { id: 2, text: "B", feature: "x" },
+    { id: 3, text: "C", feature: "y" }
+  ];
+
+  const loadHit: (string | undefined)[] = [];
+
+  const load = async ({ feature }: { feature?: string }) => {
+    loadHit.push(feature);
+    return data.filter(entry => entry.feature === feature);
+  };
+
+  const source = new Source({ container, load, cacheDuration: 2 });
+  expect(source.load()).rejects.toThrowError(Error);
+});


### PR DESCRIPTION
Change the order of arguments to `load` in source as the current order lead to issues. Also make them have defaults, similiar to the way they already work for references.

Change the way entryMap is retrieved.

Introduce stronger type checking on the source at least. We can't really make this work properly yet with references itself.