### PR TITLE
Decimal mst support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,10 +15,10 @@
     Its JSON representation is a string, but the property will be a `Decimal`
     instance.
 
-*   BREAKING CHANGE: the `converters.decimal` converter used to have a string as
-    both its value and its raw. It's been changed to have the `Decimal` object
-    as a value and can thus be used with the `decimal` type. To get the old
-    behavior you need to use `converters.stringDecimal`, so you can convert
+*   BREAKING CHANGE: the `converters.decimal` converter used to have a string
+    as both its value and its raw. It's been changed to have the `Decimal`
+    object as a value and can thus be used with the `decimal` type. To get the
+    old behavior you need to use `converters.stringDecimal`, so you can convert
     your decimal converters to this to keep your code working until you change
     it to use the new `decimal` mobx-state-tree type we introduce.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+# 1.24.0
+
+-   Better support for Decimals. Previously decimals were understood as
+    strings, but we now have a peer dependency on `decimal.js-light` which has
+    a `Decimal` object. `converters.decimal` has been changed to deliver such a
+    `Decimal` instance as a value.
+
+-   BREAKING CHANGE: the `converters.decimal` converter used have a string as
+    both its value and its raw. It's been changed to have the `Decimal` object
+    as a value. To get the old behavior you need to use
+    `converters.stringDecimal`.
+
 # 1.23.0
 
 -   BREAKING CHANGE: Change the way sources work: `load` now takes the query as

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@
     Its JSON representation is a string, but the property will be a `Decimal`
     instance.
 
-*   BREAKING CHANGE: the `converters.decimal` converter used have a string as
+*   BREAKING CHANGE: the `converters.decimal` converter used to have a string as
     both its value and its raw. It's been changed to have the `Decimal` object
     as a value and can thus be used with the `decimal` type. To get the old
     behavior you need to use `converters.stringDecimal`, so you can convert

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,9 @@
 *   BREAKING CHANGE: the `converters.decimal` converter used have a string as
     both its value and its raw. It's been changed to have the `Decimal` object
     as a value and can thus be used with the `decimal` type. To get the old
-    behavior you need to use `converters.stringDecimal`.
+    behavior you need to use `converters.stringDecimal`, so you can convert
+    your decimal converters to this to keep your code working until you change
+    it to use the new `decimal` mobx-state-tree type we introduce.
 
 # 1.23.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,24 @@
 # 1.24.0
 
--   Better support for Decimals. Previously decimals were understood as
-    strings, but we now have a peer dependency on `decimal.js-light` which has
-    a `Decimal` object. `converters.decimal` has been changed to deliver such a
-    `Decimal` instance as a value.
+-   We now have a peer dependency on `decimal.js-light` which defines a `Decimal`
+    object. We support this with a MST type and a converter (read on).
 
--   BREAKING CHANGE: the `converters.decimal` converter used have a string as
+-   We introduced a new `decimal` mobx-state-tree type you can import and use
+    within a MST model:
+
+    ```js
+    const M = types.model({
+        d: decimal
+    });
+    ```
+
+    Its JSON representation is a string, but the property will be a `Decimal`
+    instance.
+
+*   BREAKING CHANGE: the `converters.decimal` converter used have a string as
     both its value and its raw. It's been changed to have the `Decimal` object
-    as a value. To get the old behavior you need to use
-    `converters.stringDecimal`.
+    as a value and can thus be used with the `decimal` type. To get the old
+    behavior you need to use `converters.stringDecimal`.
 
 # 1.23.0
 

--- a/README.md
+++ b/README.md
@@ -352,17 +352,26 @@ other object:
 
 -   `converters.integer`: value is an integer.
 
--   `converters.decimal({maxWholeDigits:x, decimalPlaces:y, allowNegative:z})`:
-    value is a `Decimal` instance (from `decimal.js-light`) that contains a
-    decimal number with a maximum `maxWholeDigits` (default 10) before the
-    period and a maximum of `decimalPlaces` (default 2) after the period.
-    `decimalPlaces` also controls the number of decimals that is initially
-    rendered when opening the form. With `allowNegative` (boolean, default
-    true) you can specify if negative values are allowed. With
-    `normalizedDecimalPlaces` you can set the amount of decimal places the
-    converted number has. It should not be lower than `decimalPlaces`, but can
-    be higher. If it is, the given number is automatically padded with
-    additional decimal places set to 0.
+-   `converters.decimal({maxWholeDigits:x, decimalPlaces:y, allowNegative:z})`.
+    You use this with the `decimal` mobx-state-tree type that is also exported
+    by this library, like in this model:
+
+    ```js
+    const M = types.model({
+        d: decimal
+    });
+    ```
+
+    So the value that the converter delivers is a `Decimal` instance (from
+    `decimal.js-light`). It contains a decimal number with a maximum
+    `maxWholeDigits` (default 10) before the period and a maximum of
+    `decimalPlaces` (default 2) after the period. `decimalPlaces` also controls
+    the number of decimals that is initially rendered when opening the form.
+    With `allowNegative` (boolean, default true) you can specify if negative
+    values are allowed. With `normalizedDecimalPlaces` you can set the amount
+    of decimal places the converted number has. It should not be lower than
+    `decimalPlaces`, but can be higher. If it is, the given number is
+    automatically padded with additional decimal places set to 0.
 
     Conversion error types are:
 
@@ -377,8 +386,9 @@ other object:
     -   `cannotBeNegative`: you entered a negative number where this wasn't
         allowed.
 
--   `converters.decimalString(maxWholeDigits: x, decimalPlaces: y, allowNegative: z})`: like `converters.decimal` but has a `string` as its value with a
-    normalized representation of the decimal.
+-   `converters.decimalString(maxWholeDigits: x, decimalPlaces: y,
+    allowNegative: z})`: like `converters.decimal` but has a `string` as its
+    value with a normalized representation of the decimal.
 
 Number and decimal converters also respond to a handful of options through the
 use of `converterOptions`. `decimalSeparator` specifies the character used to

--- a/README.md
+++ b/README.md
@@ -353,15 +353,16 @@ other object:
 -   `converters.integer`: value is an integer.
 
 -   `converters.decimal({maxWholeDigits:x, decimalPlaces:y, allowNegative:z})`:
-    value is a string (not a number) that contains a decimal number with a
-    maximum `maxWholeDigits` (default 10) before the period and a maximum of
-    `decimalPlaces` (default 2) after the period. `decimalPlaces` also controls
-    the number of decimals that is initially rendered when opening the form.
-    With `allowNegative` (boolean, default true) you can specify if negative
-    values are allowed. With `normalizedDecimalPlaces` you can set the amount
-    of decimal places the converted number has. It should not be lower than
-    `decimalPlaces`, but can be higher. If it is, the given number is
-    automatically padded with additional decimal places set to 0.
+    value is a `Decimal` instance (from `decimal.js-light`) that contains a
+    decimal number with a maximum `maxWholeDigits` (default 10) before the
+    period and a maximum of `decimalPlaces` (default 2) after the period.
+    `decimalPlaces` also controls the number of decimals that is initially
+    rendered when opening the form. With `allowNegative` (boolean, default
+    true) you can specify if negative values are allowed. With
+    `normalizedDecimalPlaces` you can set the amount of decimal places the
+    converted number has. It should not be lower than `decimalPlaces`, but can
+    be higher. If it is, the given number is automatically padded with
+    additional decimal places set to 0.
 
     Conversion error types are:
 
@@ -375,6 +376,9 @@ other object:
 
     -   `cannotBeNegative`: you entered a negative number where this wasn't
         allowed.
+
+-   `converters.decimalString(maxWholeDigits: x, decimalPlaces: y, allowNegative: z})`: like `converters.decimal` but has a `string` as its value with a
+    normalized representation of the decimal.
 
 Number and decimal converters also respond to a handful of options through the
 use of `converterOptions`. `decimalSeparator` specifies the character used to

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
         "state management"
     ],
     "dependencies": {
-        "lodash.debounce": "^4.0.8"
+        "lodash.debounce": "^4.0.8",
+        "decimal.js-light": "^2.5.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,5 @@
     ],
     "dependencies": {
         "lodash.debounce": "^4.0.8"
-
     }
 }

--- a/package.json
+++ b/package.json
@@ -93,11 +93,13 @@
         "webpack": "^4.16.2",
         "webpack-cli": "^3.1.0",
         "webpack-dev-server": "^3.1.5",
-        "webpack-merge": "^4.1.3"
+        "webpack-merge": "^4.1.3",
+        "decimal.js-light": "^2.5.0"
     },
     "peerDependencies": {
         "mobx": "^5.15.0",
-        "mobx-state-tree": "^3.15.0"
+        "mobx-state-tree": "^3.15.0",
+        "decimal.js-light": "^2.5.0"
     },
     "keywords": [
         "mobx",
@@ -108,7 +110,7 @@
         "state management"
     ],
     "dependencies": {
-        "lodash.debounce": "^4.0.8",
-        "decimal.js-light": "^2.5.0"
+        "lodash.debounce": "^4.0.8"
+
     }
 }

--- a/src/decimal-type.ts
+++ b/src/decimal-type.ts
@@ -1,0 +1,23 @@
+import { Decimal } from "decimal.js-light";
+import { types } from "mobx-state-tree";
+
+export const decimal = types.custom<string, Decimal>({
+  name: "decimal",
+  fromSnapshot(value) {
+    return new Decimal(value);
+  },
+  toSnapshot(value) {
+    return value.toString();
+  },
+  isTargetType(value) {
+    return value instanceof Decimal;
+  },
+  getValidationMessage(snapshot) {
+    try {
+      const dummy = new Decimal(snapshot);
+    } catch (e) {
+      return "Not a valid decimal";
+    }
+    return "";
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,5 @@ export * from "./controlled";
 export * from "./state";
 export * from "./source";
 export * from "./backend";
+export * from "./decimal-type";
 export { IReferences, References, NoReferences } from "./references";

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -306,7 +306,7 @@ test("converter options in decimal converter in convert", () => {
   });
 
   const form = new Form(M, {
-    foo: new Field(converters.decimal())
+    foo: new Field(converters.stringDecimal())
   });
 
   const o = M.create({ foo: "4300.20" });
@@ -328,7 +328,7 @@ test("converter options in decimal converter in render", () => {
   });
 
   const form = new Form(M, {
-    foo: new Field(converters.decimal())
+    foo: new Field(converters.stringDecimal())
   });
 
   const o = M.create({ foo: "1234567.89" });

--- a/test/converter.test.ts
+++ b/test/converter.test.ts
@@ -70,7 +70,7 @@ test("converter maybeNull with converter options", () => {
   });
 
   const form = new Form(M, {
-    foo: new Field(converters.maybeNull(converters.decimal()))
+    foo: new Field(converters.maybeNull(converters.stringDecimal()))
   });
 
   const o = M.create({ foo: "36365.21" });

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -241,7 +241,6 @@ test("decimal converter", () => {
 });
 
 test("decimal converter for decimal type", () => {
-  ``;
   checkDecimal(converters.decimal, "3", new Decimal("3"));
   checkDecimal(converters.decimal, "3.14", new Decimal("3.14"));
   checkDecimal(converters.decimal, "-3.14", new Decimal("-3.14"));

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -1,4 +1,5 @@
 import { types } from "mobx-state-tree";
+import { Decimal } from "decimal.js-light";
 import {
   ConversionError,
   ConversionValue,
@@ -29,6 +30,18 @@ function check(
   expect((r as ConversionValue<any>).value).toEqual(expected);
 }
 
+function checkDecimal(
+  converter: ConverterOrFactory<any, any>,
+  value: string,
+  expected: Decimal
+) {
+  converter = makeConverter(converter);
+  const processedValue = converter.preprocessRaw(value, baseOptions);
+  const r = converter.convert(processedValue, baseOptions);
+  expect(r).toBeInstanceOf(ConversionValue);
+  expect((r as ConversionValue<Decimal>).value.equals(expected));
+}
+
 function checkWithOptions(
   converter: ConverterOrFactory<any, any>,
   value: any,
@@ -40,6 +53,19 @@ function checkWithOptions(
   const r = converter.convert(processedValue, options);
   expect(r).toBeInstanceOf(ConversionValue);
   expect((r as ConversionValue<any>).value).toEqual(expected);
+}
+
+function checkDecimalWithOptions(
+  converter: ConverterOrFactory<any, any>,
+  value: string,
+  expected: Decimal,
+  options: StateConverterOptionsWithContext
+) {
+  converter = makeConverter(converter);
+  const processedValue = converter.preprocessRaw(value, options);
+  const r = converter.convert(processedValue, options);
+  expect(r).toBeInstanceOf(ConversionValue);
+  expect((r as ConversionValue<Decimal>).value.equals(expected));
 }
 
 function fails(converter: ConverterOrFactory<any, any>, value: any) {
@@ -138,20 +164,20 @@ test("integer converter", () => {
 });
 
 test("decimal converter", () => {
-  check(converters.decimal, "3", "3");
-  check(converters.decimal, "3.14", "3.14");
-  check(converters.decimal, "43.14", "43.14");
-  check(converters.decimal, "4313", "4313");
-  check(converters.decimal, "-3.14", "-3.14");
-  check(converters.decimal, "0", "0");
-  check(converters.decimal, ".14", ".14");
-  check(converters.decimal, "14.", "14.");
-  checkWithOptions(converters.decimal, "43,14", "43.14", {
+  check(converters.stringDecimal, "3", "3");
+  check(converters.stringDecimal, "3.14", "3.14");
+  check(converters.stringDecimal, "43.14", "43.14");
+  check(converters.stringDecimal, "4313", "4313");
+  check(converters.stringDecimal, "-3.14", "-3.14");
+  check(converters.stringDecimal, "0", "0");
+  check(converters.stringDecimal, ".14", ".14");
+  check(converters.stringDecimal, "14.", "14.");
+  checkWithOptions(converters.stringDecimal, "43,14", "43.14", {
     decimalSeparator: ",",
     ...baseOptions
   });
   checkWithOptions(
-    converters.decimal({ decimalPlaces: 6 }),
+    converters.stringDecimal({ decimalPlaces: 6 }),
     "4.000,000000",
     "4000.000000",
     {
@@ -161,7 +187,7 @@ test("decimal converter", () => {
     }
   );
   checkWithOptions(
-    converters.decimal({ decimalPlaces: 2 }),
+    converters.stringDecimal({ decimalPlaces: 2 }),
     "36.365,21",
     "36365.21",
     {
@@ -171,42 +197,42 @@ test("decimal converter", () => {
       ...baseOptions
     }
   );
-  fails(converters.decimal, "foo");
-  fails(converters.decimal, "1foo");
-  fails(converters.decimal, "");
-  fails(converters.decimal, ".");
-  fails(converters.decimal({ maxWholeDigits: 4 }), "12345.34");
-  fails(converters.decimal({ decimalPlaces: 2 }), "12.444");
-  fails(converters.decimal({ allowNegative: false }), "-45.34");
-  failsWithOptions(converters.decimal, "1,23.45", {
+  fails(converters.stringDecimal, "foo");
+  fails(converters.stringDecimal, "1foo");
+  fails(converters.stringDecimal, "");
+  fails(converters.stringDecimal, ".");
+  fails(converters.stringDecimal({ maxWholeDigits: 4 }), "12345.34");
+  fails(converters.stringDecimal({ decimalPlaces: 2 }), "12.444");
+  fails(converters.stringDecimal({ allowNegative: false }), "-45.34");
+  failsWithOptions(converters.stringDecimal, "1,23.45", {
     decimalSeparator: ".",
     thousandSeparator: ",",
     ...baseOptions
   });
-  failsWithOptions(converters.decimal, ",12345", {
+  failsWithOptions(converters.stringDecimal, ",12345", {
     thousandSeparator: ",",
     ...baseOptions
   });
-  failsWithOptions(converters.decimal, "1234,567", {
+  failsWithOptions(converters.stringDecimal, "1234,567", {
     thousandSeparator: ",",
     ...baseOptions
   });
-  failsWithOptions(converters.decimal, "12.3,456", {
+  failsWithOptions(converters.stringDecimal, "12.3,456", {
     decimalSeparator: ".",
     thousandSeparator: ",",
     ...baseOptions
   });
-  failsWithOptions(converters.decimal, "1.1,1", {
+  failsWithOptions(converters.stringDecimal, "1.1,1", {
     decimalSeparator: ",",
     thousandSeparator: ".",
     ...baseOptions
   });
-  failsWithOptions(converters.decimal, "1,1.1", {
+  failsWithOptions(converters.stringDecimal, "1,1.1", {
     decimalSeparator: ",",
     thousandSeparator: ".",
     ...baseOptions
   });
-  failsWithOptions(converters.decimal, "1234.56", {
+  failsWithOptions(converters.stringDecimal, "1234.56", {
     decimalSeparator: ",",
     thousandSeparator: ".",
     renderThousands: true,
@@ -214,23 +240,38 @@ test("decimal converter", () => {
   });
 });
 
+test("decimal converter for decimal type", () => {
+  ``;
+  checkDecimal(converters.decimal, "3", new Decimal("3"));
+  checkDecimal(converters.decimal, "3.14", new Decimal("3.14"));
+  checkDecimal(converters.decimal, "-3.14", new Decimal("-3.14"));
+  checkDecimalWithOptions(converters.decimal, "43,14", new Decimal("43.14"), {
+    decimalSeparator: ",",
+    ...baseOptions
+  });
+  fails(converters.decimal, "foo");
+  fails(converters.decimal, "1foo");
+  fails(converters.decimal, "");
+  fails(converters.decimal, ".");
+});
+
 test("decimal converter with normalizedDecimalPlaces", () => {
   const options = { normalizedDecimalPlaces: 4 };
 
-  check(converters.decimal(options), "3", "3.0000");
-  check(converters.decimal(options), "3.14", "3.1400");
-  check(converters.decimal(options), "43.14", "43.1400");
-  check(converters.decimal(options), "4313", "4313.0000");
-  check(converters.decimal(options), "-3.14", "-3.1400");
-  check(converters.decimal(options), "0", "0.0000");
-  check(converters.decimal(options), ".14", ".1400");
-  check(converters.decimal(options), "14.", "14.0000");
-  checkWithOptions(converters.decimal(options), "43,14", "43.1400", {
+  check(converters.stringDecimal(options), "3", "3.0000");
+  check(converters.stringDecimal(options), "3.14", "3.1400");
+  check(converters.stringDecimal(options), "43.14", "43.1400");
+  check(converters.stringDecimal(options), "4313", "4313.0000");
+  check(converters.stringDecimal(options), "-3.14", "-3.1400");
+  check(converters.stringDecimal(options), "0", "0.0000");
+  check(converters.stringDecimal(options), ".14", ".1400");
+  check(converters.stringDecimal(options), "14.", "14.0000");
+  checkWithOptions(converters.stringDecimal(options), "43,14", "43.1400", {
     decimalSeparator: ",",
     ...baseOptions
   });
   checkWithOptions(
-    converters.decimal({ decimalPlaces: 6, normalizedDecimalPlaces: 7 }),
+    converters.stringDecimal({ decimalPlaces: 6, normalizedDecimalPlaces: 7 }),
     "4.000,000000",
     "4000.0000000",
     {
@@ -240,7 +281,7 @@ test("decimal converter with normalizedDecimalPlaces", () => {
     }
   );
   checkWithOptions(
-    converters.decimal({ decimalPlaces: 2, normalizedDecimalPlaces: 4 }),
+    converters.stringDecimal({ decimalPlaces: 2, normalizedDecimalPlaces: 4 }),
     "36.365,21",
     "36365.2100",
     {
@@ -253,7 +294,7 @@ test("decimal converter with normalizedDecimalPlaces", () => {
 });
 
 test("decimal converter with both options", () => {
-  checkWithOptions(converters.decimal, "4.314.314,31", "4314314.31", {
+  checkWithOptions(converters.stringDecimal, "4.314.314,31", "4314314.31", {
     decimalSeparator: ",",
     thousandSeparator: ".",
     ...baseOptions
@@ -261,7 +302,7 @@ test("decimal converter with both options", () => {
 });
 
 test("decimal converter render with renderThousands false", () => {
-  const converter = converters.decimal({});
+  const converter = converters.stringDecimal({});
   const options = {
     decimalSeparator: ",",
     thousandSeparator: ".",
@@ -279,7 +320,7 @@ test("decimal converter render with renderThousands false", () => {
 });
 
 test("decimal converter render with six decimals", () => {
-  const converter = converters.decimal({ decimalPlaces: 6 });
+  const converter = converters.stringDecimal({ decimalPlaces: 6 });
   const options = {
     decimalSeparator: ".",
     thousandSeparator: ",",
@@ -297,7 +338,7 @@ test("decimal converter render with six decimals", () => {
 });
 
 test("decimal converter render with six decimals and thousand separators", () => {
-  const converter = converters.decimal({ decimalPlaces: 6 });
+  const converter = converters.stringDecimal({ decimalPlaces: 6 });
   const options = {
     decimalSeparator: ".",
     thousandSeparator: ",",
@@ -315,7 +356,7 @@ test("decimal converter render with six decimals and thousand separators", () =>
 });
 
 test("decimal converter render with six decimals, only showing three", () => {
-  const converter = converters.decimal({ decimalPlaces: 3 });
+  const converter = converters.stringDecimal({ decimalPlaces: 3 });
   const options = {
     decimalSeparator: ",",
     thousandSeparator: ".",
@@ -329,7 +370,7 @@ test("decimal converter render with six decimals, only showing three", () => {
 
 test("decimal converter with thousandSeparator . and no decimalSeparator can't convert", () => {
   let message = false;
-  const converter = converters.decimal();
+  const converter = converters.stringDecimal();
   const options = {
     thousandSeparator: ".",
     renderThousands: true,
@@ -368,16 +409,16 @@ test("maybeNull number converter", () => {
 });
 
 test("maybe decimal converter", () => {
-  check(converters.maybe(converters.decimal()), "3.14", "3.14");
-  check(converters.maybe(converters.decimal()), "", undefined);
-  const c = converters.maybe(converters.decimal());
+  check(converters.maybe(converters.stringDecimal()), "3.14", "3.14");
+  check(converters.maybe(converters.stringDecimal()), "", undefined);
+  const c = converters.maybe(converters.stringDecimal());
   expect(c.render(undefined, baseOptions)).toEqual("");
 });
 
 test("maybeNull decimal converter", () => {
-  check(converters.maybeNull(converters.decimal()), "3.14", "3.14");
-  check(converters.maybeNull(converters.decimal()), "", null);
-  const c = converters.maybeNull(converters.decimal());
+  check(converters.maybeNull(converters.stringDecimal()), "3.14", "3.14");
+  check(converters.maybeNull(converters.stringDecimal()), "", null);
+  const c = converters.maybeNull(converters.stringDecimal());
   expect(c.render(null, baseOptions)).toEqual("");
 });
 
@@ -463,7 +504,7 @@ test("dynamic decimal converter", () => {
 
   const form = new Form(M, {
     foo: new Field(
-      converters.dynamic(converters.decimal, context => context.options)
+      converters.dynamic(converters.stringDecimal, context => context.options)
     )
   });
 
@@ -541,7 +582,7 @@ test("render decimal number without decimals with decimal separator", () => {
 
   const form = new Form(M, {
     foo: new Field(
-      converters.dynamic(converters.decimal, context => ({
+      converters.dynamic(converters.stringDecimal, context => ({
         allowNegative: false,
         decimalPlaces: getCurrencyDecimals(context.getCurrency())
       }))
@@ -599,7 +640,7 @@ test("obey addZeroes false", () => {
   const form = new Form(M, {
     foo: new Field(
       converters.maybeNull(
-        converters.decimal({ decimalPlaces: 6, addZeroes: false })
+        converters.stringDecimal({ decimalPlaces: 6, addZeroes: false })
       )
     )
   });
@@ -620,7 +661,7 @@ test("obey addZeroes true", () => {
   const form = new Form(M, {
     foo: new Field(
       converters.maybeNull(
-        converters.decimal({ decimalPlaces: 6, addZeroes: true })
+        converters.stringDecimal({ decimalPlaces: 6, addZeroes: true })
       )
     )
   });
@@ -641,7 +682,7 @@ test("maybe decimal converter/render for empty", () => {
   const form = new Form(M, {
     foo: new Field(
       converters.maybeNull(
-        converters.decimal({ decimalPlaces: 6, addZeroes: false })
+        converters.stringDecimal({ decimalPlaces: 6, addZeroes: false })
       )
     )
   });

--- a/test/decimal-type.test.ts
+++ b/test/decimal-type.test.ts
@@ -1,6 +1,6 @@
-import { decimal } from "../src/";
 import { Decimal } from "decimal.js-light";
 import { types, getSnapshot, typecheck } from "mobx-state-tree";
+import { decimal } from "../src/";
 
 test("decimal reading and writing", () => {
   const M = types

--- a/test/decimal-type.test.ts
+++ b/test/decimal-type.test.ts
@@ -1,0 +1,33 @@
+import { decimal } from "../src/";
+import { Decimal } from "decimal.js-light";
+import { types, getSnapshot, typecheck } from "mobx-state-tree";
+
+test("decimal reading and writing", () => {
+  const M = types
+    .model({
+      d: decimal
+    })
+    .actions(self => ({
+      setDecimal(d: Decimal) {
+        self.d = d;
+      }
+    }));
+
+  const o = M.create({ d: "1.25" });
+  // this is a Decimal instance, so we can call a method on it
+  expect(o.d.isPositive()).toBeTruthy();
+  expect(o.d.equals(new Decimal("1.25"))).toBeTruthy();
+  const snapshot = getSnapshot(o);
+  expect(snapshot).toEqual({
+    d: "1.25"
+  });
+});
+
+test("decimal validation", () => {
+  // shouldn't throw
+  typecheck(decimal, "1.25");
+
+  // should throw
+  expect(() => typecheck(decimal, "02-04-2013")).toThrow();
+  expect(() => typecheck(decimal, "borked")).toThrow();
+});

--- a/test/derived.test.ts
+++ b/test/derived.test.ts
@@ -288,13 +288,15 @@ test("calculated with context", () => {
 
   const form = new Form(M, {
     calculated: new Field(
-      converters.dynamic(converters.decimal, getDecimalPlaces),
+      converters.dynamic(converters.stringDecimal, getDecimalPlaces),
       {
         derived: (node: Instance<typeof M>) => node.sum()
       }
     ),
-    a: new Field(converters.dynamic(converters.decimal, getDecimalPlaces)),
-    b: new Field(converters.dynamic(converters.decimal, getDecimalPlaces))
+    a: new Field(
+      converters.dynamic(converters.stringDecimal, getDecimalPlaces)
+    ),
+    b: new Field(converters.dynamic(converters.stringDecimal, getDecimalPlaces))
   });
 
   const o = M.create({ calculated: "0.0000", a: "1.0000", b: "2.3456" });

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -16,8 +16,8 @@ test("dynamic based on accessor", () => {
   };
 
   const form = new Form(M, {
-    foo: new Field(converters.dynamic(converters.decimal, getOptions)),
-    bar: new Field(converters.dynamic(converters.decimal, getOptions))
+    foo: new Field(converters.dynamic(converters.stringDecimal, getOptions)),
+    bar: new Field(converters.dynamic(converters.stringDecimal, getOptions))
   });
 
   const o = M.create({ foo: "1.2", bar: "3.4" });
@@ -44,7 +44,7 @@ test("dynamic converter with maybe", () => {
 
   const form = new Form(M, {
     foo: new Field(
-      converters.maybe(converters.dynamic(converters.decimal, getOptions))
+      converters.maybe(converters.dynamic(converters.stringDecimal, getOptions))
     )
   });
 
@@ -72,7 +72,9 @@ test("dynamic converter with maybeNull", () => {
 
   const form = new Form(M, {
     foo: new Field(
-      converters.maybeNull(converters.dynamic(converters.decimal, getOptions))
+      converters.maybeNull(
+        converters.dynamic(converters.stringDecimal, getOptions)
+      )
     )
   });
 

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -2097,7 +2097,7 @@ test("form with thousandSeparator . and empty decimalSeparator invalid", () => {
   const o = M.create({ foo: "3000" });
 
   const form = new Form(M, {
-    foo: new Field(converters.decimal())
+    foo: new Field(converters.stringDecimal())
   });
 
   expect(() => {
@@ -2115,7 +2115,7 @@ test("form with thousandSeparator and decimalSeparator same value invalid", () =
   const o = M.create({ foo: "3000" });
 
   const form = new Form(M, {
-    foo: new Field(converters.decimal())
+    foo: new Field(converters.stringDecimal())
   });
 
   expect(() => {
@@ -2135,9 +2135,12 @@ test("blur hook with postprocess", () => {
   });
 
   const form = new Form(M, {
-    foo: new Field(converters.decimal({ decimalPlaces: 2, addZeroes: true }), {
-      postprocess: true
-    }),
+    foo: new Field(
+      converters.stringDecimal({ decimalPlaces: 2, addZeroes: true }),
+      {
+        postprocess: true
+      }
+    ),
     bar: new Field(converters.string)
   });
 
@@ -2167,9 +2170,12 @@ test("blur hook no postprocess with error", () => {
   });
 
   const form = new Form(M, {
-    foo: new Field(converters.decimal({ decimalPlaces: 2, addZeroes: true }), {
-      postprocess: true
-    })
+    foo: new Field(
+      converters.stringDecimal({ decimalPlaces: 2, addZeroes: true }),
+      {
+        postprocess: true
+      }
+    )
   });
 
   const o = M.create({ foo: "4314314" });
@@ -2197,7 +2203,7 @@ test("blur hook with postprocess maybe field", () => {
   const form = new Form(M, {
     foo: new Field(
       converters.maybeNull(
-        converters.decimal({ decimalPlaces: 2, addZeroes: true })
+        converters.stringDecimal({ decimalPlaces: 2, addZeroes: true })
       ),
       {
         postprocess: true
@@ -2230,7 +2236,7 @@ test("setValueAndUpdateRaw", () => {
   const o = M.create({ foo: "" });
 
   const form = new Form(M, {
-    foo: new Field(converters.decimal())
+    foo: new Field(converters.stringDecimal())
   });
 
   const state = form.state(o, {
@@ -2413,7 +2419,7 @@ test("isEmpty on fields", () => {
     maybeNullString: new Field(converters.maybeNull(converters.string)),
     boolean: new Field(converters.boolean),
     textStringArray: new Field(converters.textStringArray),
-    decimal: new Field(converters.decimal({ decimalPlaces: 2 }))
+    decimal: new Field(converters.stringDecimal({ decimalPlaces: 2 }))
   });
 
   const o = M.create({
@@ -2493,7 +2499,7 @@ test("isEmptyAndRequired on fields", () => {
     maybeNullString: new Field(converters.maybeNull(converters.string)),
     boolean: new Field(converters.boolean),
     textStringArray: new Field(converters.textStringArray),
-    decimal: new Field(converters.decimal({ decimalPlaces: 2 })),
+    decimal: new Field(converters.stringDecimal({ decimalPlaces: 2 })),
     requiredString: new Field(converters.string, {
       required: true
     }),
@@ -2509,7 +2515,7 @@ test("isEmptyAndRequired on fields", () => {
     requiredTextStringArray: new Field(converters.textStringArray, {
       required: true
     }),
-    requiredDecimal: new Field(converters.decimal({ decimalPlaces: 2 }), {
+    requiredDecimal: new Field(converters.stringDecimal({ decimalPlaces: 2 }), {
       required: true
     })
   });

--- a/test/multiple-conversion-errors.test.ts
+++ b/test/multiple-conversion-errors.test.ts
@@ -12,7 +12,7 @@ test("conversion failure with multiple messages", () => {
 
   const form = new Form(M, {
     foo: new Field(
-      converters.decimal({
+      converters.stringDecimal({
         allowNegative: false,
         decimalPlaces: 4,
         maxWholeDigits: 4
@@ -63,7 +63,7 @@ test("conversion failure with multiple messages, context", () => {
 
   const form = new Form(M, {
     foo: new Field(
-      converters.decimal({
+      converters.stringDecimal({
         allowNegative: false,
         decimalPlaces: 4,
         maxWholeDigits: 4

--- a/yarn.lock
+++ b/yarn.lock
@@ -1774,6 +1774,11 @@ decamelize@^2.0.0:
   dependencies:
     xregexp "4.0.0"
 
+decimal.js-light@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.0.tgz#ca7faf504c799326df94b0ab920424fdfc125348"
+  integrity sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"


### PR DESCRIPTION
* introduce decimal.js-light as a (peer) dependency.
* implement a 'decimal' mobx-state-tree field.
* change the 'decimal' converter to work with this new field.
* the old behavior is in the 'stringDecimal' converter.
