### PR TITLE
Bugfix/dispose on remove

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.24.1
+
+-   We now dispose the `autoLoadReaction` for references when a node is
+    removed. This is needed to prevent the `autoLoadReaction` from being
+    triggered while the node is no longer present.
+
 # 1.24.0
 
 -   We now have a peer dependency on `decimal.js-light` which defines a `Decimal`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.24.0",
+    "version": "1.24.1",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -62,6 +62,9 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
   }
 
   dispose() {
+    if (this.references.isEnabled()) {
+      this.references.clearAutoLoadReaction();
+    }
     if (this._disposer == null) {
       return;
     }

--- a/src/references.ts
+++ b/src/references.ts
@@ -8,6 +8,7 @@ export interface IReferences<
   DQ extends Query
 > {
   autoLoadReaction(): IReactionDisposer;
+  clearAutoLoadReaction(): void;
   load(searchQuery?: SQ): Promise<Instance<T>[]>;
   loadWithTimestamp(
     timestamp: number,
@@ -32,8 +33,10 @@ export class References<
     public dependentQuery: DependentQuery<DQ> = () => ({} as DQ)
   ) {}
 
+  _autoLoadDisposer: IReactionDisposer | undefined;
+
   autoLoadReaction(): IReactionDisposer {
-    return reaction(
+    this._autoLoadDisposer = reaction(
       () => {
         return this.dependentQuery();
       },
@@ -41,6 +44,14 @@ export class References<
         this.load();
       }
     );
+    return this._autoLoadDisposer;
+  }
+
+  clearAutoLoadReaction(): void {
+    if (this._autoLoadDisposer === undefined) {
+      return;
+    }
+    this._autoLoadDisposer();
   }
 
   getFullQuery(searchQuery?: SQ): SQ & DQ {
@@ -80,6 +91,10 @@ export class References<
 export class NoReferences<SQ extends Query, DQ extends Query>
   implements IReferences<any, SQ, DQ> {
   autoLoadReaction(): IReactionDisposer {
+    throw new Error(`No references defined`);
+  }
+
+  clearAutoLoadReaction(): void {
     throw new Error(`No references defined`);
   }
 

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -1,6 +1,6 @@
 import { configure } from "mobx";
 import { types, getSnapshot } from "mobx-state-tree";
-import { Source, Form, converters, Field } from "../src";
+import { Source, Form, converters, Field, RepeatingForm } from "../src";
 import { resolveReactions } from "./util";
 
 // "always" leads to trouble during initialization.
@@ -353,6 +353,61 @@ describe("source accessor in fields", () => {
 
     disposeA();
     disposeB();
+  });
+
+  test("form with autoLoad disposes on delete", async () => {
+    const n = types.model("N", {
+      foo: types.array(M),
+      containerA: ContainerA,
+      containerB: ContainerB
+    });
+
+    const r = n.create({
+      foo: [
+        {
+          a: undefined,
+          b: undefined
+        }
+      ],
+      containerA: { entryMap: {} },
+      containerB: { entryMap: {} }
+    });
+
+    const containerA = r.containerA;
+    const containerB = r.containerB;
+
+    const sourceA = new Source({ entryMap: containerA.entryMap, load: loadA });
+    const sourceB = new Source({ entryMap: containerB.entryMap, load: loadB });
+
+    const form = new Form(n, {
+      foo: new RepeatingForm({
+        a: new Field(converters.maybe(converters.model(ItemA)), {
+          references: {
+            source: sourceA
+          }
+        }),
+        b: new Field(converters.maybe(converters.model(ItemB)), {
+          references: {
+            source: sourceB,
+            // this source is dependent on state. This information
+            // should be sent whenever a load is issued
+            dependentQuery: accessor => {
+              return { a: accessor.node.a, c: accessor.node.c };
+            }
+          }
+        })
+      })
+    });
+    const state = form.state(r);
+    const repeating = state.repeatingForm("foo");
+    const firstLine = repeating.index(0);
+
+    const fieldA = firstLine.field("a");
+    const fieldB = firstLine.field("b");
+    fieldA.references.autoLoadReaction();
+    fieldB.references.autoLoadReaction();
+
+    repeating.remove(r.foo[0]);
   });
 
   test("no references", async () => {

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -379,6 +379,8 @@ describe("source accessor in fields", () => {
     const sourceA = new Source({ entryMap: containerA.entryMap, load: loadA });
     const sourceB = new Source({ entryMap: containerB.entryMap, load: loadB });
 
+    let dependentQueryCounter = 0;
+
     const form = new Form(n, {
       foo: new RepeatingForm({
         a: new Field(converters.maybe(converters.model(ItemA)), {
@@ -392,6 +394,7 @@ describe("source accessor in fields", () => {
             // this source is dependent on state. This information
             // should be sent whenever a load is issued
             dependentQuery: accessor => {
+              dependentQueryCounter += 1;
               return { a: accessor.node.a, c: accessor.node.c };
             }
           }
@@ -407,7 +410,11 @@ describe("source accessor in fields", () => {
     fieldA.references.autoLoadReaction();
     fieldB.references.autoLoadReaction();
 
+    expect(dependentQueryCounter).toEqual(1);
+
     repeating.remove(r.foo[0]);
+
+    expect(dependentQueryCounter).toEqual(1);
   });
 
   test("no references", async () => {


### PR DESCRIPTION
This PR implements the disposing of the `autoLoadReaction` when a node is cleared.
This to prevent the reaction from being called while the node is already removed.