### PR TITLE
Error on toplevel repeatingform subform structures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.24.3
+
+-   We now also render subforms, repeatingforms, and indexed repeatingforms
+    as invalid if the accessor itself has feedback.
+
 # 1.24.2
 
 -   We now also take the `formAccessor` into account when clearing

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -63,7 +63,10 @@ export class RepeatingFormAccessor<
 
   @computed
   get isValid(): boolean {
-    return this.accessors.every(accessor => accessor.isValid);
+    return (
+      this.errorValue == null &&
+      this.accessors.every(accessor => accessor.isValid)
+    );
   }
 
   @computed

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -42,6 +42,14 @@ export class RepeatingFormIndexedAccessor<
   }
 
   @computed
+  get isValid(): boolean {
+    return (
+      this.errorValue == null &&
+      this.accessors.every(accessor => accessor.isValid)
+    );
+  }
+
+  @computed
   get value(): any {
     return this.state.getValue(this.path);
   }

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -30,4 +30,12 @@ export class SubFormAccessor<
   get value(): any {
     return this.state.getValue(this.path);
   }
+
+  @computed
+  get isValid(): boolean {
+    return (
+      this.errorValue == null &&
+      this.accessors.every(accessor => accessor.isValid)
+    );
+  }
 }

--- a/test/accessor.test.ts
+++ b/test/accessor.test.ts
@@ -98,12 +98,17 @@ test("groups with repeatingform error on top-level", async () => {
     getError: (accessor: any) =>
       accessor instanceof RepeatingFormAccessor && accessor.length === 0
         ? "Cannot be empty"
+        : undefined,
+    getWarning: (accessor: any) =>
+      accessor instanceof RepeatingFormAccessor
+        ? "Some some reason this is insufficient"
         : undefined
   });
 
   const repeatingForm = state.repeatingForm("foo");
 
   expect(repeatingForm.isValid).toBeFalsy();
+  expect(repeatingForm.isWarningFree).toBeFalsy();
 });
 
 test("groups with indexed repeatingform error on top-level", async () => {
@@ -126,6 +131,10 @@ test("groups with indexed repeatingform error on top-level", async () => {
     getError: (accessor: any) =>
       accessor instanceof RepeatingFormIndexedAccessor
         ? "For some reason this is wrong"
+        : undefined,
+    getWarning: (accessor: any) =>
+      accessor instanceof RepeatingFormIndexedAccessor
+        ? "Some some reason this is insufficient"
         : undefined
   });
 
@@ -133,4 +142,5 @@ test("groups with indexed repeatingform error on top-level", async () => {
   const indexedRepeatingForm = repeatingForm.index(0);
 
   expect(indexedRepeatingForm.isValid).toBeFalsy();
+  expect(indexedRepeatingForm.isWarningFree).toBeFalsy();
 });

--- a/test/subform.test.ts
+++ b/test/subform.test.ts
@@ -161,9 +161,14 @@ test("groups with subform error on top-level", async () => {
 
   const state = form.state(o, {
     getError: (accessor: any) =>
-      accessor instanceof SubFormAccessor ? "Somehow this is wrong" : undefined
+      accessor instanceof SubFormAccessor ? "Somehow this is wrong" : undefined,
+    getWarning: (accessor: any) =>
+      accessor instanceof SubFormAccessor
+        ? "Somehow this is insufficient"
+        : undefined
   });
   const subForm = state.subForm("sub");
 
   expect(subForm.isValid).toBeFalsy();
+  expect(subForm.isWarningFree).toBeFalsy();
 });


### PR DESCRIPTION
Validation were triggered on form substructures' accessors (repeatingForms, indexedRepeatingForms, subForms) only if any underlying accessor had any validation. Possible validations that are triggered on the (main) accessor itself would not render it as invalid.

`isValid` will now also trigger on validations that are triggered directly on RepeatingFormAccessor, RepeatingFormIndexedAccessor, and SubFormAccessor. Furthermore, any groups they belong in are similarly invalidated.