### PR TITLE
Source reuse existing load when available

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "tslint": "^5.8.0",
         "tslint-config-prettier": "^1.1.0",
         "tslint-config-standard": "^9.0.0",
-        "typescript": "3.6.3",
+        "typescript": "3.9.5",
         "validate-commit-msg": "^2.12.2",
         "webpack": "^4.16.2",
         "webpack-cli": "^3.1.0",

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -157,13 +157,7 @@ export class Backend<M extends IAnyModelType> {
       console.error("Unexpected error during process:", e);
       return;
     }
-    const completeProcessResult: ProcessResult = {
-      updates: [],
-      accessUpdates: [],
-      errorValidations: [],
-      warningValidations: [],
-      ...processResult
-    };
+    const completeProcessResult: ProcessResult = processResult;
     this.runProcessResult(completeProcessResult);
   }
 

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -36,7 +36,9 @@ export interface SaveFunc<M> {
 }
 
 export interface Process<M> {
-  (node: Instance<M>, path: string, liveOnly: boolean): Promise<ProcessResult>;
+  (node: Instance<M>, path: string, liveOnly: boolean): Promise<
+    Partial<ProcessResult>
+  >;
 }
 
 export interface ProcessAll<M> {
@@ -157,7 +159,13 @@ export class Backend<M extends IAnyModelType> {
       console.error("Unexpected error during process:", e);
       return;
     }
-    const completeProcessResult: ProcessResult = processResult;
+    const completeProcessResult: ProcessResult = {
+      updates: [],
+      accessUpdates: [],
+      errorValidations: [],
+      warningValidations: [],
+      ...processResult
+    };
     this.runProcessResult(completeProcessResult);
   }
 

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,6 @@ import {
   unprotect,
   getRoot
 } from "mobx-state-tree";
-import { timingSafeEqual } from "crypto";
 
 export type Query = {};
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "moduleResolution": "node",
         "target": "es5",
         "module": "es2015",
-        "lib": ["es2015", "es2016", "es2017", "dom"],
+        "lib": ["es2015", "es2016", "es2017", "es2020", "dom"],
         "sourceMap": true,
         "strict": true,
         "strictPropertyInitialization": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6631,10 +6631,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
This PR involves 2 things:

- Upgrade typescript. I needed to use `Promise.allSettled`. The typings for it have been added in typescript 3.8, so I decided to upgrade the typescript version to the one we use in our project.

- In our project we came to the conclusion that when multiple widgets with the same source are loaded at the same time it initiates a load for each widget, which results in a lot of requests. Thus I made it so that when a load is already running for the given query it will return the same promise. This results in only one request.

@faassen if you need more info we can discuss this monday.

Note that `Promise.allSettled` is supported from node version 12.0+. So to be able to run tests locally you should install node 12.0+.