### PR TITLE
Process should trigger not live validations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # 1.24.4
 
 -   Assure that the `processAll` function triggers non-live validations in order
-    to trigger warnings on the first attempt.
+    to trigger warnings on the first attempt. You can pass the optional parameter
+    `liveOnly` to the function to manually trigger all validations, or just the
+    live ones.
 
 # 1.24.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,7 @@
 # 1.24.4
 
--   Assure that the `processAll` function triggers non-live validations in order
-    to trigger warnings on the first attempt. You can pass the optional parameter
-    `liveOnly` to the function to manually trigger all validations, or just the
-    live ones.
+-   You can pass the optional parameter `liveOnly` to the `processAll` function
+    to manually trigger all validations, or just the live ones.
 
 # 1.24.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.24.4
+
+-   Assure that the `processAll` function triggers non-live validations in order
+    to trigger warnings on the first attempt.
+
 # 1.24.3
 
 -   We now also render subforms, repeatingforms, and indexed repeatingforms

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -122,13 +122,16 @@ export class Backend<M extends IAnyModelType> {
     return false;
   }
 
-  async realProcessAll() {
+  async realProcessAll(liveOnly?: boolean) {
     if (this.processAll == null) {
       throw new Error(
         "Cannot process all if processAll function is not configured"
       );
     }
-    const processResult = await this.processAll(this.node, this.state.liveOnly);
+    const processResult = await this.processAll(
+      this.node,
+      liveOnly || this.state.liveOnly
+    );
     this.clearValidations();
 
     const completeProcessResult: ProcessResult = {

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -130,7 +130,7 @@ export class Backend<M extends IAnyModelType> {
     }
     const processResult = await this.processAll(
       this.node,
-      liveOnly || this.state.liveOnly
+      liveOnly != null ? liveOnly : this.state.liveOnly
     );
     this.clearValidations();
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -289,7 +289,6 @@ export class FormState<
 
   @computed
   get liveOnly(): boolean {
-    //hittng 'process' should also validate non-live validations
     return this.saveStatus === "before";
   }
 

--- a/src/state.ts
+++ b/src/state.ts
@@ -289,6 +289,7 @@ export class FormState<
 
   @computed
   get liveOnly(): boolean {
+    //hittng 'process' should also validate non-live validations
     return this.saveStatus === "before";
   }
 
@@ -419,6 +420,7 @@ export class FormState<
     if (this.processor == null) {
       throw new Error("Cannot process all without backend configuration");
     }
+    this.setSaveStatus("after");
 
     return this.processor.realProcessAll();
   }

--- a/src/state.ts
+++ b/src/state.ts
@@ -415,13 +415,13 @@ export class FormState<
   }
 
   @action
-  async processAll() {
+  async processAll(liveOnly?: boolean) {
     if (this.processor == null) {
       throw new Error("Cannot process all without backend configuration");
     }
     this.setSaveStatus("after");
 
-    return this.processor.realProcessAll();
+    return this.processor.realProcessAll(liveOnly);
   }
 
   @action

--- a/src/state.ts
+++ b/src/state.ts
@@ -419,7 +419,6 @@ export class FormState<
     if (this.processor == null) {
       throw new Error("Cannot process all without backend configuration");
     }
-    this.setSaveStatus("after");
 
     return this.processor.realProcessAll(liveOnly);
   }

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -873,12 +873,12 @@ test("processAll and liveOnly", async () => {
   });
 
   await state.processAll();
-  expect(liveSeen).toEqual([false]);
+  expect(liveSeen).toEqual([true]);
 
   await state.save();
 
   await state.processAll();
-  expect(liveSeen).toEqual([false, false]);
+  expect(liveSeen).toEqual([true, false]);
 });
 
 test("processAll and liveOnly overrule", async () => {
@@ -915,13 +915,13 @@ test("processAll and liveOnly overrule", async () => {
     }
   });
 
-  await state.processAll(true);
-  expect(liveSeen).toEqual([true]);
+  await state.processAll(false);
+  expect(liveSeen).toEqual([false]);
 
   await state.save();
 
   await state.processAll(true);
-  expect(liveSeen).toEqual([true, true]);
+  expect(liveSeen).toEqual([false, true]);
 });
 
 test("reset liveOnly status", async () => {

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -873,13 +873,13 @@ test("processAll and liveOnly", async () => {
   });
 
   await state.processAll();
-  expect(liveSeen).toEqual([true]);
+  expect(liveSeen).toEqual([false]);
 
   await state.save();
 
   await state.processAll();
 
-  expect(liveSeen).toEqual([true, false]);
+  expect(liveSeen).toEqual([false, false]);
 });
 
 test("reset liveOnly status", async () => {

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -878,8 +878,50 @@ test("processAll and liveOnly", async () => {
   await state.save();
 
   await state.processAll();
-
   expect(liveSeen).toEqual([false, false]);
+});
+
+test("processAll and liveOnly overrule", async () => {
+  const M = types.model("M", {
+    foo: types.string
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.string)
+  });
+
+  const o = M.create({ foo: "FOO" });
+
+  const liveSeen: boolean[] = [];
+
+  async function myProcessAll(node: Instance<typeof M>, liveOnly: boolean) {
+    liveSeen.push(liveOnly);
+    return {
+      updates: [],
+      errorValidations: [],
+      warningValidations: []
+    };
+  }
+
+  async function mySave(node: Instance<typeof M>) {
+    return null;
+  }
+
+  const state = form.state(o, {
+    backend: {
+      processAll: myProcessAll,
+      save: mySave,
+      debounce: debounce
+    }
+  });
+
+  await state.processAll(true);
+  expect(liveSeen).toEqual([true]);
+
+  await state.save();
+
+  await state.processAll(true);
+  expect(liveSeen).toEqual([true, true]);
 });
 
 test("reset liveOnly status", async () => {


### PR DESCRIPTION
Minor fix in which we assure that the `processAll` method also triggers non-live validations.
In the old situation, the processAll would not change the `liveOnly` flag until after the first trigger. This meant that a form with only warnings would simply process, and a form with both errors and warnings would first show the errors, afterwards the warnings would triggered in the second try. Now both warnings and errors are triggered.