### PR TITLE
Add a new property to display a flexible minimum amount of decimals. …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
 -   Export a few convenience types: `IAnySubFormAccessor`,
     `IAnyRepeatingFormAccessor`, `IAnyRepeatingFormIndexedAccessor`.
 
+-   Add a `minimalFlexibleDecimals` option to the `decimal` converter. This is
+    useful if you only want to display the number of decimals we actually have:
+    It does not show the trailing zeros after this minimal number of decimals.
+
 # 1.25.0
 
 -   You can pass the optional parameter `liveOnly` to the `processAll` function

--- a/src/decimalParser.ts
+++ b/src/decimalParser.ts
@@ -39,6 +39,7 @@ export type DecimalOptions = {
   addZeroes: boolean;
   allowNegative: boolean;
   normalizedDecimalPlaces?: number;
+  minimalFlexibleDecimals?: number;
 };
 
 type TokenOptions = {
@@ -134,13 +135,24 @@ export function parseDecimal(s: string, options: Options): string {
   if (options.normalizedDecimalPlaces == null) {
     return converted;
   }
-  return normalize(converted, options.normalizedDecimalPlaces);
+
+  // flexible number of decimals or standard normalizedDecimalPlaces?
+  const trailingZeros =
+    options.minimalFlexibleDecimals == null
+      ? options.normalizedDecimalPlaces
+      : options.minimalFlexibleDecimals;
+  return normalize(converted, trailingZeros);
 }
 
 function normalize(decimal: string, amount: number): string {
   const parts = decimal.split(".");
   const beforePeriod = parts[0];
   const decimals = parts.length === 2 ? parts[1] : "";
+
+  // do we need to add trailing zeros ?
+  if (decimals.length >= amount) {
+    return beforePeriod + "." + decimals;
+  }
   return beforePeriod + "." + addZeroes(decimals, amount);
 }
 

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -292,6 +292,54 @@ test("decimal converter with normalizedDecimalPlaces", () => {
   );
 });
 
+test("decimal converter with minimalFlexibleDecimals", () => {
+  const options = {
+    decimalPlaces: 6,
+    normalizedDecimalPlaces: 4,
+    minimalFlexibleDecimals: 3
+  };
+
+  check(converters.stringDecimal(options), "3", "3.000");
+  check(converters.stringDecimal(options), "3.14", "3.140");
+  check(converters.stringDecimal(options), "43.14", "43.140");
+  check(converters.stringDecimal(options), "4313", "4313.000");
+  check(converters.stringDecimal(options), "-3.14", "-3.140");
+  check(converters.stringDecimal(options), "0", "0.000");
+  check(converters.stringDecimal(options), ".14", ".140");
+  check(converters.stringDecimal(options), "14.", "14.000");
+  check(converters.stringDecimal(options), ".143", ".143");
+
+  // show more decimals because we have more decimals than three
+  check(converters.stringDecimal(options), ".1434", ".1434");
+  check(converters.stringDecimal(options), ".14345", ".14345");
+
+  checkWithOptions(converters.stringDecimal(options), "43,14", "43.140", {
+    decimalSeparator: ",",
+    ...baseOptions
+  });
+  checkWithOptions(
+    converters.stringDecimal({ decimalPlaces: 6, normalizedDecimalPlaces: 7 }),
+    "4.000,000000",
+    "4000.0000000",
+    {
+      decimalSeparator: ",",
+      thousandSeparator: ".",
+      ...baseOptions
+    }
+  );
+  checkWithOptions(
+    converters.stringDecimal({ decimalPlaces: 2, normalizedDecimalPlaces: 4 }),
+    "36.365,21",
+    "36365.2100",
+    {
+      decimalSeparator: ",",
+      thousandSeparator: ".",
+      renderThousands: true,
+      ...baseOptions
+    }
+  );
+});
+
 test("decimal converter with both options", () => {
   checkWithOptions(converters.stringDecimal, "4.314.314,31", "4314314.31", {
     decimalSeparator: ",",

--- a/test/decimalParser.test.ts
+++ b/test/decimalParser.test.ts
@@ -135,6 +135,31 @@ test("normalizedDecimalPlaces", () => {
   expect(parseDecimal("-4", options)).toEqual("-4.0000");
 });
 
+test("minimalFlexibleDecimals", () => {
+  const options = {
+    maxWholeDigits: 50,
+    decimalPlaces: 6,
+    normalizedDecimalPlaces: 4,
+    minimalFlexibleDecimals: 3,
+    allowNegative: true,
+    decimalSeparator: ".",
+    thousandSeparator: ",",
+    renderThousands: true,
+    addZeroes: true
+  };
+  expect(parseDecimal("12,345.45", options)).toEqual("12345.450");
+  expect(parseDecimal(".12", options)).toEqual(".120");
+  expect(parseDecimal("3", options)).toEqual("3.000");
+  expect(parseDecimal("-4", options)).toEqual("-4.000");
+
+  // show more decimals because we have more decimals than three
+  expect(parseDecimal(".1234", options)).toEqual(".1234");
+  expect(parseDecimal(".12345", options)).toEqual(".12345");
+
+  // do not allow more than 6 decimals
+  expect(() => parseDecimal(".1234567", options)).toThrow();
+});
+
 test("numbers without thousand separators", () => {
   // as a special case we accept numbers without thousand separators too
   expect(parseDecimal("1000", options)).toEqual("1000");


### PR DESCRIPTION
Add a new property to display a flexible minimum amount of decimals. Show more if we have more.

Added this new property for a customer that is wishing to display prices in at least 2 and at most 10 decimals.
But, if, for instance, a price does not have more than 3 decimals, we do not want to show all trailing zeros
