### PR TITLE
Add a new property to display a flexible minimum amount of decimals. …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.27.0
+
+-   Add a `maxZeroesPadding` option to the `decimal` renderer.
+    `maxZeroesPadding` can be set to limit the number of trailing zeros. This to
+    display a flexible minimum amount of decimals. Show more if we have more.
+
 # 1.26.0
 
 -   Upgraded Typescript to version `4.0.3` and upgrade various testing
@@ -16,10 +22,6 @@
 
 -   Export a few convenience types: `IAnySubFormAccessor`,
     `IAnyRepeatingFormAccessor`, `IAnyRepeatingFormIndexedAccessor`.
-
--   Add a `maxZeroesPadding` option to the `decimal` renderer.
-    `maxZeroesPadding` can be set to limit the number of trailing zeros. This to
-    display a flexible minimum amount of decimals. Show more if we have more.
 
 # 1.25.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
 -   Export a few convenience types: `IAnySubFormAccessor`,
     `IAnyRepeatingFormAccessor`, `IAnyRepeatingFormIndexedAccessor`.
 
+-   Add a `maxZeroesPadding` option to the `decimal` renderer.
+    `maxZeroesPadding` can be set to limit the number of trailing zeros. This to
+    display a flexible minimum amount of decimals. Show more if we have more.
+
 # 1.25.0
 
 -   You can pass the optional parameter `liveOnly` to the `processAll` function

--- a/README.md
+++ b/README.md
@@ -396,6 +396,11 @@ separate the integral and fractional part of a number or decimal.
 `thousandSeparator` specifies the character used to group thousands together.
 `renderThousands` determines whether or not the thousand separators should be
 rendered.
+`maxZeroesPadding` can be set to limit the number of trailing zeros. This to
+display a flexible minimum amount of decimals. Show more if we have more. Added
+this new property for a customer that is wishing to display prices in at least 2
+and at most 10 decimals. But, if, for instance, a price does not have more than
+3 decimals, we do not want to show all trailing zeros
 
 ### Boolean
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.25.0",
+    "version": "1.27.0",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/decimalParser.ts
+++ b/src/decimalParser.ts
@@ -39,6 +39,7 @@ export type DecimalOptions = {
   addZeroes: boolean;
   allowNegative: boolean;
   normalizedDecimalPlaces?: number;
+  maxZeroesPadding?: number;
 };
 
 type TokenOptions = {
@@ -62,7 +63,17 @@ function thousands(wholeDigits: string, thousandSeparator: string): string {
 }
 
 function trimDecimals(decimalDigits: string, decimalPlaces: number): string {
-  return decimalDigits.slice(0, decimalPlaces);
+  // remove all trailing zeroes
+  // reverse loop until there are no trailing zeroes anymore
+  let result = decimalDigits.split("");
+  for (let i = result.length - 1; i >= 0; i--) {
+    if (result[i] === "0") {
+      result[i] = "";
+    } else {
+      break;
+    }
+  }
+  return result.join("").slice(0, decimalPlaces);
 }
 
 function addZeroes(decimalDigits: string, decimalPlaces: number): string {
@@ -91,7 +102,13 @@ export function renderDecimal(s: string, options: Options): string {
 
   decimalDigits = trimDecimals(decimalDigits, options.decimalPlaces);
   if (options.addZeroes) {
-    decimalDigits = addZeroes(decimalDigits, options.decimalPlaces);
+    let decimalPlaces = options.decimalPlaces;
+    if (options.maxZeroesPadding != null) {
+      decimalPlaces = options.maxZeroesPadding;
+    }
+    if (decimalPlaces - decimalDigits.length > 0) {
+      decimalDigits = addZeroes(decimalDigits, decimalPlaces);
+    }
   }
 
   const result =

--- a/test/decimalParser.test.ts
+++ b/test/decimalParser.test.ts
@@ -208,3 +208,28 @@ test("empty render no addZeroes", () => {
   };
   expect(renderDecimal("", options)).toEqual("");
 });
+
+test("render addZeroes maxZeroesPadding", () => {
+  const options = {
+    maxWholeDigits: 50,
+    decimalPlaces: 4,
+    allowNegative: true,
+    decimalSeparator: ".",
+    thousandSeparator: ",",
+    renderThousands: false,
+    addZeroes: true,
+    maxZeroesPadding: 2
+  };
+  expect(renderDecimal("100", options)).toEqual("100.00");
+  expect(renderDecimal("1234", options)).toEqual("1234.00");
+  expect(renderDecimal("1.12", options)).toEqual("1.12");
+  expect(renderDecimal(".12", options)).toEqual(".12");
+  expect(renderDecimal(".12345", options)).toEqual(".1234");
+  expect(renderDecimal("12345678", options)).toEqual("12345678.00");
+  expect(renderDecimal("-1.5", options)).toEqual("-1.50");
+  expect(renderDecimal("-100", options)).toEqual("-100.00");
+  expect(renderDecimal("100.0000000000", options)).toEqual("100.00");
+  expect(renderDecimal("100.1200000000", options)).toEqual("100.12");
+  expect(renderDecimal("100.1234000000", options)).toEqual("100.1234");
+  expect(renderDecimal("100.1234500000", options)).toEqual("100.1234");
+});


### PR DESCRIPTION
`maxZeroesPadding` can be set to limit the number of trailing zeros. This to
display a flexible minimum amount of decimals. Show more if we have more. Added
this new property for a customer that is wishing to display prices in at least 2
and at most 10 decimals. But, if, for instance, a price does not have more than
3 decimals, we do not want to show all trailing zeros