### PR TITLE
Only set local raw when explicitly calling setRaw.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.28.0
+
+-   The performance of `validate` on the form state has been improved.
+
 # 1.27.1
 
 -   BREAKING CHANGE: `textStringArray` now filters out empty lines via `preProcessRaw`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.27.1",
+    "version": "1.28.0",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -239,7 +239,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
   validate(options?: ValidateOptions): boolean {
     const ignoreRequired = options != null ? options.ignoreRequired : false;
     const ignoreGetError = options != null ? options.ignoreGetError : false;
-    this.validateRaw(this.raw, { ignoreRequired });
+    this.setValueFromRaw(this.raw, { ignoreRequired });
     if (ignoreGetError) {
       return this.isInternallyValid;
     }
@@ -265,7 +265,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
   }
 
   @action
-  validateRaw(raw: R, options?: ProcessOptions) {
+  setValueFromRaw(raw: R, options?: ProcessOptions) {
     const stateConverterOptions = this.state.stateConverterOptionsWithContext(
       this
     );
@@ -317,7 +317,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
 
     this._raw = raw;
 
-    this.validateRaw(raw, options);
+    this.setValueFromRaw(raw, options);
   }
 
   @action

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -239,7 +239,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
   validate(options?: ValidateOptions): boolean {
     const ignoreRequired = options != null ? options.ignoreRequired : false;
     const ignoreGetError = options != null ? options.ignoreGetError : false;
-    this.setRaw(this.raw, { ignoreRequired });
+    this.validateRaw(this.raw, { ignoreRequired });
     if (ignoreGetError) {
       return this.isInternallyValid;
     }
@@ -265,13 +265,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
   }
 
   @action
-  setRaw(raw: R, options?: ProcessOptions) {
-    if (this.state.saveStatus === "rightAfter") {
-      this.state.setSaveStatus("after");
-    }
-
-    this._raw = raw;
-
+  validateRaw(raw: R, options?: ProcessOptions) {
     const stateConverterOptions = this.state.stateConverterOptionsWithContext(
       this
     );
@@ -313,6 +307,17 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
     }
 
     this.setValue(processResult.value);
+  }
+
+  @action
+  setRaw(raw: R, options?: ProcessOptions) {
+    if (this.state.saveStatus === "rightAfter") {
+      this.state.setSaveStatus("after");
+    }
+
+    this._raw = raw;
+
+    this.validateRaw(raw, options);
   }
 
   @action


### PR DESCRIPTION
Turned out to be a very simple change - simply not setting the local _raw in validate was enough to improve frontend validate performance while still keeping the original behavior intact. All tests still pass without any changes and I couldn't find any changes in application behavior either.