### PR TITLE
Add minLength option to string converter.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.29.0
+
+-   The string converter can now take the option `minLength`, which validates
+    your string on if it contains too few characters.
+
 # 1.28.0
 
 -   The performance of `validate` on the form state has been improved.

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -30,6 +30,7 @@ export class StringConverter<V> extends Converter<string, V> {
 
 type StringOptions = {
   maxLength?: number;
+  minLength?: number;
 };
 
 function string(options: StringOptions) {
@@ -39,6 +40,9 @@ function string(options: StringOptions) {
     convert(raw) {
       if (options.maxLength != null && options.maxLength < raw.length) {
         throw new ConversionError("exceedsMaxLength");
+      }
+      if (options.minLength != null && options.minLength > raw.length) {
+        throw new ConversionError("failsMinLength");
       }
       return raw;
     },

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -93,6 +93,8 @@ test("string converter", () => {
 test("string converter with options", () => {
   check(converters.string({ maxLength: 32 }), "foo", "foo");
   fails(converters.string({ maxLength: 2 }), "foo");
+  check(converters.string({ minLength: 2 }), "foo", "foo");
+  fails(converters.string({ minLength: 4 }), "foo");
 });
 
 test("number converter", () => {


### PR DESCRIPTION
We already had a maxLength option for string converters, but we also desired to have a minLength option. This PR adds this feature.