### PR TITLE
Add dirty check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+# 1.31.0
+
+- Exposed `IFormAccessor<any, any, any>` type as `IAnyFormAccessor` and `FormState<any, any, any>` as AnyFormState.
+- Added isEnabled and associated methods/properties in the same manner as isHidden().
+- Enabled terser minify for production builds.
+- Fixed MyFormProps typescript error.
+- Added test to verify derived field does not change when its value is the same as before.
+- Updated contributors list.
+
 # 1.30.0
 
 - Added a `literalString` converter, supporting the `types.literal` type from `mobx-state-tree`.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -8,3 +8,7 @@ Contributors:
 -   Koen de Leijer
 -   Randy Wanga
 -   Rick Lucassen
+-   Mark den Toom
+-   Ruben van de Kerkhof
+-   Guus Biemans
+-   Robin van Grinsven

--- a/README.md
+++ b/README.md
@@ -1722,7 +1722,7 @@ When saving the form and the save was succesful the dirty state will be reset,
 so the state after saving will be set as the initial value on every
 `FieldAccessor`.
 
-Manually resetting the dirty state can be done by calling `resetDirtyStates` on
+Manually resetting the dirty state can be done by calling `resetDirtyState` on
 the `FormState` or `resetDirtyState` on any other `accessor`.
 
 ## Tips

--- a/README.md
+++ b/README.md
@@ -1708,6 +1708,23 @@ only do this if you have nothing pointing to entries in its underlying
 Note: mstform does not yet not implement any cache eviction facilities, either
 from the container or from the search results.
 
+## Dirty state
+
+For every field accessor we keep a copy of the initial value to determine
+whether the fields value has been changed or not. This initial value does
+include any value that has been set through `addModeDefaults`.
+
+Every `accessor` has a property `isDirty` to check whether something has
+changed, this can be any `accessor` like `RepeatingFormAccessor`,
+`FormAccessor`, `FieldAccessor`, `GroupAccessor`.
+
+When saving the form and the save was succesful the dirty state will be reset,
+so the state after saving will be set as the initial value on every
+`FieldAccessor`.
+
+Manually resetting the dirty state can be done by calling `resetDirtyStates` on
+the `FormState` or `resetDirtyState` on any other `accessor`.
+
 ## Tips
 
 - Don't name your form state `this.state` on a React component as this has a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.30.0",
+    "version": "1.31.0",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/accessor-base.ts
+++ b/src/accessor-base.ts
@@ -38,6 +38,7 @@ export abstract class AccessorBase implements IAccessor {
   abstract get addMode(): boolean;
   abstract get value(): any;
   abstract get isValid(): boolean;
+  abstract get isDirty(): boolean;
   abstract accessBySteps(steps: string[]): IAccessor | undefined;
   abstract validate(options?: ValidateOptions): boolean;
 

--- a/src/accessor-base.ts
+++ b/src/accessor-base.ts
@@ -41,6 +41,7 @@ export abstract class AccessorBase implements IAccessor {
   abstract get isDirty(): boolean;
   abstract accessBySteps(steps: string[]): IAccessor | undefined;
   abstract validate(options?: ValidateOptions): boolean;
+  abstract resetDirtyState(): void;
 
   constructor(public parent: IParentAccessor) {
     makeObservable(this);

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -31,8 +31,6 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
   @observable
   _raw: R | undefined;
 
-  @observable _originalRaw: R | undefined;
-
   @observable
   _value: V;
 

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -52,7 +52,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
     makeObservable(this);
     this.createDerivedReaction();
     this._value = state.getValue(this.path);
-    this._originalValue = this._value;
+    this._originalValue = toJS(this._value);
     if (field.options && field.options.references) {
       const options = field.options.references;
       const dependentQuery = options.dependentQuery || (() => ({}));
@@ -277,7 +277,16 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
     if (this.addMode) {
       return false;
     }
-    return this.value !== this._originalValue;
+    if (Array.isArray(this.value)) {
+      return toJS(this.value).length !== this._originalValue.length;
+    }
+
+    const jsValue = toJS(this.value);
+
+    if (jsValue != null && (jsValue as any).constructor == {}.constructor) {
+      return JSON.stringify(jsValue) !== JSON.stringify(this._originalValue);
+    }
+    return jsValue !== this._originalValue;
   }
 
   @computed

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -289,6 +289,10 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
     return jsValue !== this._originalValue;
   }
 
+  resetDirtyState(): void {
+    this._originalValue = toJS(this._value);
+  }
+
   @computed
   get requiredError(): string {
     const requiredError = this.field.requiredError || this.state._requiredError;

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -31,8 +31,12 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
   @observable
   _raw: R | undefined;
 
+  @observable _originalRaw: R | undefined;
+
   @observable
   _value: V;
+
+  _originalValue: any;
 
   _disposer: IReactionDisposer | undefined;
 
@@ -48,6 +52,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
     makeObservable(this);
     this.createDerivedReaction();
     this._value = state.getValue(this.path);
+    this._originalValue = this._value;
     if (field.options && field.options.references) {
       const options = field.options.references;
       const dependentQuery = options.dependentQuery || (() => ({}));
@@ -265,6 +270,14 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
   @computed
   get isValid(): boolean {
     return this.errorValue === undefined;
+  }
+
+  @computed
+  get isDirty(): boolean {
+    if (this.addMode) {
+      return false;
+    }
+    return this.value !== this._originalValue;
   }
 
   @computed

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -83,6 +83,10 @@ export abstract class FormAccessorBase<
     return this.accessors.some((accessor) => accessor.isDirty);
   }
 
+  resetDirtyState(): void {
+    this.accessors.forEach((accessor) => accessor.resetDirtyState());
+  }
+
   @computed
   get accessors(): IAccessor[] {
     const result: IAccessor[] = [];

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -1,4 +1,4 @@
-import { observable, computed, action, makeObservable } from "mobx";
+import { observable, computed, action, makeObservable, override } from "mobx";
 import { IAnyModelType, Instance } from "mobx-state-tree";
 
 import {
@@ -76,6 +76,11 @@ export abstract class FormAccessorBase<
   @computed
   get isValid(): boolean {
     return this.accessors.every((accessor) => accessor.isValid);
+  }
+
+  @computed
+  get isDirty(): boolean {
+    return this.accessors.some((accessor) => accessor.isDirty);
   }
 
   @computed

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -25,11 +25,7 @@ export class GroupAccessor<D extends FormDefinition<any>> {
 
   @computed
   get isDirty(): boolean {
-    throw new Error("Not implemented for group accessor");
-  }
-
-  resetDirtyState(): void {
-    throw new Error("Not implemented for group accessor");
+    return this.hasFeedback(this.isDirtyForNames.bind(this));
   }
 
   hasFeedback(feedbackFunc: (names: (keyof D)[]) => boolean): boolean {
@@ -69,6 +65,16 @@ export class GroupAccessor<D extends FormDefinition<any>> {
         return true;
       }
       return accessor.isWarningFree;
+    });
+  }
+
+  isDirtyForNames(names: (keyof D)[]): boolean {
+    return names.some((key) => {
+      const accessor = this.parent.access(key as string);
+      if (accessor == null) {
+        return false;
+      }
+      return accessor.isDirty;
     });
   }
 }

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -15,20 +15,35 @@ export class GroupAccessor<D extends FormDefinition<any>> {
 
   @computed
   get isValid(): boolean {
-    return this.hasFeedback(this.isValidForNames.bind(this));
+    return this.handleNames(this.isValidForNames.bind(this));
   }
 
   @computed
   get isWarningFree(): boolean {
-    return this.hasFeedback(this.isWarningFreeForNames.bind(this));
+    return this.handleNames(this.isWarningFreeForNames.bind(this));
   }
 
   @computed
   get isDirty(): boolean {
-    return this.hasFeedback(this.isDirtyForNames.bind(this));
+    return this.handleNames(this.isDirtyForNames.bind(this));
   }
 
-  hasFeedback(feedbackFunc: (names: (keyof D)[]) => boolean): boolean {
+  resetDirtyState(): void {
+    this.handleNames(this.handleResetDirtyState.bind(this));
+  }
+
+  handleResetDirtyState(names: (keyof D)[]): boolean {
+    names.forEach((key) => {
+      const accessor = this.parent.access(key as string);
+      if (accessor == null) {
+        return true;
+      }
+      return accessor.resetDirtyState();
+    });
+    return true;
+  }
+
+  handleNames(feedbackFunc: (names: (keyof D)[]) => boolean): boolean {
     const include = this.group.options.include;
     const exclude = this.group.options.exclude;
     if (include != null && exclude != null) {

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -23,6 +23,11 @@ export class GroupAccessor<D extends FormDefinition<any>> {
     return this.hasFeedback(this.isWarningFreeForNames.bind(this));
   }
 
+  @computed
+  get isDirty(): boolean {
+    throw new Error("Not implemented for group accessor");
+  }
+
   hasFeedback(feedbackFunc: (names: (keyof D)[]) => boolean): boolean {
     const include = this.group.options.include;
     const exclude = this.group.options.exclude;

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -28,6 +28,10 @@ export class GroupAccessor<D extends FormDefinition<any>> {
     throw new Error("Not implemented for group accessor");
   }
 
+  resetDirtyState(): void {
+    throw new Error("Not implemented for group accessor");
+  }
+
   hasFeedback(feedbackFunc: (names: (keyof D)[]) => boolean): boolean {
     const include = this.group.options.include;
     const exclude = this.group.options.exclude;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -34,6 +34,7 @@ export interface IAccessor {
   validate(options?: ValidateOptions): boolean;
 
   isValid: boolean;
+  isDirty: boolean;
 
   accessors: IAccessor[];
   flatAccessors: IAccessor[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,6 +39,7 @@ export interface IAccessor {
   accessors: IAccessor[];
   flatAccessors: IAccessor[];
   accessBySteps(steps: string[]): IAccessor | undefined;
+  resetDirtyState(): void;
 
   dispose(): void;
   clear(): void;

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -32,6 +32,7 @@ export class RepeatingFormAccessor<
 
   externalErrors = new ExternalMessages();
   externalWarnings = new ExternalMessages();
+  _initialLength = 0;
 
   constructor(
     public state: AnyFormState,
@@ -43,6 +44,7 @@ export class RepeatingFormAccessor<
     makeObservable(this);
     this.name = name;
     this.initialize();
+    this._initialLength = this.length;
   }
 
   @computed
@@ -77,6 +79,14 @@ export class RepeatingFormAccessor<
   @computed
   get addMode(): boolean {
     return this.parent.addMode;
+  }
+
+  @computed
+  get isDirty(): boolean {
+    if (this.length != this._initialLength) {
+      return true;
+    }
+    return this.accessors.some((accessor) => accessor.isDirty);
   }
 
   initialize() {

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -89,6 +89,11 @@ export class RepeatingFormAccessor<
     return this.accessors.some((accessor) => accessor.isDirty);
   }
 
+  resetDirtyState(): void {
+    this._initialLength = this.length;
+    this.accessors.forEach((accessor) => accessor.resetDirtyState());
+  }
+
   initialize() {
     const entries = this.state.getValue(this.path);
     let i = 0;

--- a/src/state.ts
+++ b/src/state.ts
@@ -437,12 +437,12 @@ export class FormState<
     }
 
     return this.processor.realSave().then((result) => {
-      this.resetDirtyStates();
+      this.resetDirtyState();
       return result;
     });
   }
 
-  resetDirtyStates() {
+  resetDirtyState() {
     this.flatAccessors.forEach((accessor) => {
       accessor.resetDirtyState();
     });

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,6 +5,7 @@ import {
   applyPatch,
   IAnyModelType,
   Instance,
+  clone,
 } from "mobx-state-tree";
 
 import {

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,7 +5,6 @@ import {
   applyPatch,
   IAnyModelType,
   Instance,
-  clone,
 } from "mobx-state-tree";
 
 import {

--- a/src/state.ts
+++ b/src/state.ts
@@ -436,7 +436,16 @@ export class FormState<
       return false;
     }
 
-    return this.processor.realSave();
+    return this.processor.realSave().then((result) => {
+      this.resetDirtyStates();
+      return result;
+    });
+  }
+
+  resetDirtyStates() {
+    this.flatAccessors.forEach((accessor) => {
+      accessor.resetDirtyState();
+    });
   }
 
   @action

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -2892,6 +2892,14 @@ test("isdirty form and field in addmode with group", async () => {
   expect(fieldBar.isDirty).toBeFalsy();
   expect(fieldBlop.isDirty).toBeTruthy();
   expect(state.isDirty).toBeTruthy();
+
+  fieldFoo.setRaw("something else");
+  expect(fieldFoo.isDirty).toBeTruthy();
+  expect(group.isDirty).toBeTruthy();
+  group.resetDirtyState();
+  expect(group.isDirty).toBeFalsy();
+  expect(fieldFoo.isDirty).toBeFalsy();
+  expect(fieldBlop.isDirty).toBeTruthy();
 });
 
 test("isdirty form and field in addmode and addmodedefaults", () => {


### PR DESCRIPTION
This PR adds functionality for dirty checks on accessors.

For each accessor the initial value (this also includes any value through `addModeDefaults`) is saved and compared to see if this has been changed ever since.

After a succesful save of the `FormAccessor` the initial value is updated and thus the dirty state is reset.

Each `accessor` has a `isDirty` property to check for this state, also a `resetDirtyState` is present on each `accessor` to reset this manually.