### PR TITLE
Revert state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1725,6 +1725,12 @@ so the state after saving will be set as the initial value on every
 Manually resetting the dirty state can be done by calling `resetDirtyState` on
 the `FormState` or `resetDirtyState` on any other `accessor`.
 
+## Restore state
+
+Every accessor has a `restore` method to restore its value to the original state.
+
+After succesfully saving a `FormAccessor` the original state is replaced.
+
 ## Tips
 
 - Don't name your form state `this.state` on a React component as this has a

--- a/src/accessor-base.ts
+++ b/src/accessor-base.ts
@@ -42,6 +42,7 @@ export abstract class AccessorBase implements IAccessor {
   abstract accessBySteps(steps: string[]): IAccessor | undefined;
   abstract validate(options?: ValidateOptions): boolean;
   abstract resetDirtyState(): void;
+  abstract restore(): void;
 
   constructor(public parent: IParentAccessor) {
     makeObservable(this);

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -296,9 +296,7 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
       if (jsValue.length !== this._originalValue.length) {
         return true;
       }
-      return (
-        JSON.stringify(toJS(this.value)) !== JSON.stringify(this._originalValue)
-      );
+      return JSON.stringify(jsValue) !== JSON.stringify(this._originalValue);
     }
 
     if (isStateTreeNode(this.value) && isModelType(getType(this.value))) {

--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -83,6 +83,14 @@ export abstract class FormAccessorBase<
     return this.accessors.some((accessor) => accessor.isDirty);
   }
 
+  restore(): void {
+    // If this accessor is not dirty, don't bother to restore.
+    if (!this.isDirty) {
+      return;
+    }
+    this.accessors.forEach((accessor) => accessor.restore());
+  }
+
   resetDirtyState(): void {
     this.accessors.forEach((accessor) => accessor.resetDirtyState());
   }

--- a/src/group-accessor.ts
+++ b/src/group-accessor.ts
@@ -28,8 +28,23 @@ export class GroupAccessor<D extends FormDefinition<any>> {
     return this.handleNames(this.isDirtyForNames.bind(this));
   }
 
+  restore(): void {
+    this.handleNames(this.handleRestore.bind(this));
+  }
+
   resetDirtyState(): void {
     this.handleNames(this.handleResetDirtyState.bind(this));
+  }
+
+  handleRestore(names: (keyof D)[]): boolean {
+    names.forEach((key) => {
+      const accessor = this.parent.access(key as string);
+      if (accessor == null) {
+        return true;
+      }
+      return accessor.restore();
+    });
+    return true;
   }
 
   handleResetDirtyState(names: (keyof D)[]): boolean {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -40,6 +40,7 @@ export interface IAccessor {
   flatAccessors: IAccessor[];
   accessBySteps(steps: string[]): IAccessor | undefined;
   resetDirtyState(): void;
+  restore(): void;
 
   dispose(): void;
   clear(): void;
@@ -90,6 +91,7 @@ export interface IRepeatingFormIndexedAccessor<
   M extends IAnyModelType
 > extends IFormAccessor<D, G, M> {
   index: number;
+  _hash: string;
 
   setIndex(index: number): void;
   setAddMode(addModeDefaults: string[]): void;

--- a/src/repeating-form-accessor.ts
+++ b/src/repeating-form-accessor.ts
@@ -120,14 +120,14 @@ export class RepeatingFormAccessor<
       return;
     }
 
-    // If hashed do match we don't need to restore any removed lines or remove
+    // If hashes do match we don't need to restore any removed lines or remove
     // newly added ones.
     if (this.hashesMatch) {
       this.accessors.forEach((accessor) => accessor.restore());
       return;
     }
 
-    // If hashed do not match we need to restore from the original snapshot.
+    // If hashes do not match we need to restore from the original snapshot.
     applyPatch(this.state.node, {
       op: "replace",
       path: this.path,

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -20,6 +20,10 @@ export class RepeatingFormIndexedAccessor<
   @observable
   index: number;
 
+  // Store hash to easily determine whether we are (still) dealing with the same
+  // accessors in the parent.
+  _hash: string = (Math.random() + 1).toString(36).substring(4);
+
   constructor(
     public state: AnyFormState,
     definition: D,


### PR DESCRIPTION
As an extension of the dirty state this adds the ability to revert to the previous state. While implementing this I had to change/improve some dirty state detection.

Basically this adds the ability to call `restore()` on every accessor to restore its value to the previous state.

For repeating accessors I had to implement hashes on the indexed accessors to determine whether the nested accessors where still the same or not. This made the dirty check of repeating accessors a lot faster and easier.