### PR TITLE
NEXTPL-252 add support for enforceActions: "always"

### DIFF
--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -1,4 +1,10 @@
-import { observable, computed, action, makeObservable, override } from "mobx";
+import {
+  observable,
+  computed,
+  action,
+  makeObservable,
+  runInAction,
+} from "mobx";
 import { IAnyModelType, Instance } from "mobx-state-tree";
 
 import {
@@ -52,7 +58,9 @@ export abstract class FormAccessorBase<
     super(parent);
     makeObservable(this);
     this.keys = Object.keys(this.definition);
-    this._addMode = addMode;
+    runInAction(() => {
+      this._addMode = addMode;
+    });
   }
 
   validate(options?: ValidateOptions): boolean {
@@ -182,6 +190,7 @@ export abstract class FormAccessorBase<
     return accessor.accessBySteps(rest);
   }
 
+  @action
   initialize() {
     this.keys.forEach((key) => {
       const entry = this.definition[key];

--- a/test/accessor.test.ts
+++ b/test/accessor.test.ts
@@ -11,8 +11,7 @@ import {
   Group,
 } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("accessByPath simple field", () => {
   const M = types.model("M", {

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -5,8 +5,7 @@ import { debounce, until } from "./utils";
 
 jest.useFakeTimers();
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("backend process sets error messages", async () => {
   const M = types.model("M", {

--- a/test/changehook.test.ts
+++ b/test/changehook.test.ts
@@ -2,8 +2,7 @@ import { configure } from "mobx";
 import { types } from "mobx-state-tree";
 import { Field, Form, converters } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("changehook", () => {
   const M = types

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -10,8 +10,7 @@ import {
   ConversionError,
 } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("context passed to field accessor", () => {
   const M = types.model("M", {

--- a/test/controlled.test.ts
+++ b/test/controlled.test.ts
@@ -1,7 +1,7 @@
 import { configure } from "mobx";
 import { types } from "mobx-state-tree";
 import { converters, controlled, Form, Field } from "../src";
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("object controlled", () => {
   const M = types.model("M", {

--- a/test/converter.test.ts
+++ b/test/converter.test.ts
@@ -3,7 +3,7 @@ import { types } from "mobx-state-tree";
 import { Field, Form, converters, FieldAccessor } from "../src";
 import { ConversionValue, Converter, ConversionError } from "../src/converter";
 
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 const options = {
   // a BIG lie. but we don't really have an accessor in these

--- a/test/derived.test.ts
+++ b/test/derived.test.ts
@@ -2,8 +2,7 @@ import { configure, IReactionDisposer } from "mobx";
 import { types, Instance } from "mobx-state-tree";
 import { Field, Form, RepeatingForm, converters } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("calculated", () => {
   const M = types

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -8,8 +8,7 @@ import {
 } from "mobx-state-tree";
 import { Field, Form, RepeatingForm, converters, Group } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("a simple form", () => {
   const M = types.model("M", {

--- a/test/groups.test.ts
+++ b/test/groups.test.ts
@@ -12,8 +12,7 @@ import {
   converters,
 } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("groups basic", () => {
   const M = types.model("M", {

--- a/test/ignore.test.ts
+++ b/test/ignore.test.ts
@@ -2,8 +2,7 @@ import { configure } from "mobx";
 import { types, Instance } from "mobx-state-tree";
 import { Field, Form, RepeatingForm, SubForm, converters } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("setRaw with required ignore", () => {
   const M = types.model("M", {

--- a/test/multiple-conversion-errors.test.ts
+++ b/test/multiple-conversion-errors.test.ts
@@ -2,8 +2,7 @@ import { configure } from "mobx";
 import { types } from "mobx-state-tree";
 import { Field, Form, converters } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("conversion failure with multiple messages", () => {
   const M = types.model("M", {

--- a/test/navigate.test.ts
+++ b/test/navigate.test.ts
@@ -6,12 +6,10 @@ import {
   SubForm,
   RepeatingForm,
   converters,
-  IFormAccessor,
   IAnyFormAccessor,
 } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("value for state", () => {
   const M = types.model("M", {

--- a/test/source.test.ts
+++ b/test/source.test.ts
@@ -3,8 +3,7 @@ import { types, getSnapshot } from "mobx-state-tree";
 import { Source, Form, converters, Field, RepeatingForm } from "../src";
 import { resolveReactions } from "./utils";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 function refSnapshots(refs: any[] | undefined): any[] {
   if (refs === undefined) {

--- a/test/subform.test.ts
+++ b/test/subform.test.ts
@@ -2,8 +2,7 @@ import { configure } from "mobx";
 import { types } from "mobx-state-tree";
 import { Field, Form, SubForm, SubFormAccessor, converters } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("a sub form", () => {
   const N = types.model("N", {

--- a/test/viewhook.test.ts
+++ b/test/viewhook.test.ts
@@ -9,7 +9,7 @@ import {
   ValidationProps,
 } from "../src";
 
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("custom validationProps", () => {
   const M = types.model("M", {

--- a/test/warning.test.ts
+++ b/test/warning.test.ts
@@ -11,8 +11,7 @@ import {
   converters,
 } from "../src";
 
-// "always" leads to trouble during initialization.
-configure({ enforceActions: "observed" });
+configure({ enforceActions: "always" });
 
 test("a simple warning", async () => {
   const M = types.model("M", {


### PR DESCRIPTION
The warnings that are triggered during the constructor setting of observable values are "intended" (paraphrasing mwestrate): no specific detection for that can be used since those constructor functions are not detectable at runtime.
A workaround is using runInAction() to set those variables in the constructor.

added @action decorator to form-accessor-base's initialize() to fix warnings with enforceActions: always
Wrapped this._addmode = addmode in constructor of form-accessor-base in runInAction() to fix warnings with enforceActions: always

Above 2 fixes all the warnings that were triggered during tests with `enforceActions: "always"` 
The demo runs without the error/warning mentioned in the linked issue https://github.com/isprojects/mstform/issues/76.