### PR TITLE
Add support for modelReferenceArray type

### DIFF
--- a/src/controlled.ts
+++ b/src/controlled.ts
@@ -1,3 +1,10 @@
+import {
+  applyPatch,
+  IAnyModelType,
+  IMSTArray,
+  Instance,
+  IReferenceType,
+} from "mobx-state-tree";
 import { FieldAccessor } from "./field-accessor";
 
 export interface Controlled {
@@ -25,8 +32,25 @@ const object: Controlled = (accessor) => {
   };
 };
 
+const modelReferenceArray: Controlled = (
+  accessor: FieldAccessor<
+    Instance<IAnyModelType>[],
+    IMSTArray<IReferenceType<IAnyModelType>>
+  >
+) => {
+  return {
+    value: accessor.raw,
+    onChange: (value: Instance<IAnyModelType>[]) => {
+      applyPatch(accessor.node, [
+        { op: "replace", path: accessor.path, value: value },
+      ]);
+    },
+  };
+};
+
 export const controlled = {
   value,
   checked,
   object,
+  modelReferenceArray,
 };

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -1,5 +1,10 @@
 import { IObservableArray, observable } from "mobx";
-import { IAnyModelType, Instance } from "mobx-state-tree";
+import {
+  IAnyModelType,
+  IMSTArray,
+  Instance,
+  IReferenceType,
+} from "mobx-state-tree";
 import { Decimal } from "decimal.js-light";
 import {
   Converter,
@@ -359,6 +364,20 @@ function maybeModel<M, RE, VE>(
   });
 }
 
+function modelReferenceArray<M extends IAnyModelType>(_model: M) {
+  return new Converter<Instance<M>[], IMSTArray<IReferenceType<M>>>({
+    emptyRaw: [],
+    emptyValue: observable.array([]),
+    defaultControlled: controlled.modelReferenceArray,
+    convert(raw) {
+      return raw as IMSTArray<IReferenceType<M>>;
+    },
+    render(value) {
+      return value;
+    },
+  });
+}
+
 const object = new Converter<any, any>({
   emptyRaw: null,
   emptyValue: undefined,
@@ -389,6 +408,7 @@ export const converters = {
   maybe,
   maybeNull,
   model,
+  modelReferenceArray,
   object,
   dynamic,
 };

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -31,6 +31,8 @@ import {
   getType,
   getIdentifier,
   isStateTreeNode,
+  isReferenceType,
+  getChildType,
 } from "mobx-state-tree";
 
 export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
@@ -189,12 +191,17 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
     const result = this._raw;
     if (result !== undefined) {
       // this is an object reference. don't convert to JS
-      if (isObservable(result) && !(result instanceof Array)) {
+      // or if this is an array of references, don't convert to JS.
+      if (
+        (isObservable(result) && !(result instanceof Array)) ||
+        (isObservable(result) &&
+          result instanceof Array &&
+          isStateTreeNode(result) &&
+          isReferenceType(getChildType(result)))
+      ) {
         return result as R;
       }
-      // anything else, including arrays, convert to JS
-      // XXX what if we have an array of object references? cross that
-      // bridge when we support it
+
       return toJS(result) as R;
     }
     if (this.addMode) {

--- a/test/controlled.test.ts
+++ b/test/controlled.test.ts
@@ -23,7 +23,7 @@ test("object controlled", () => {
   expect(field.raw).toEqual("BAR");
 });
 
-test("modelArray controlled", () => {
+test("modelReferenceArray controlled", () => {
   const Bar = types.model("Bar", {
     id: types.identifierNumber,
     name: types.string,

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -445,7 +445,7 @@ test("model converter", () => {
   expect(r2).toEqual({ value: o });
 });
 
-test("modelArray converter", () => {
+test("modelReferenceArray converter", () => {
   const Foo = types.model("Foo", {
     id: types.identifierNumber,
     name: types.string,

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -445,6 +445,20 @@ test("model converter", () => {
   expect(r2).toEqual({ value: o });
 });
 
+test("modelArray converter", () => {
+  const Foo = types.model("Foo", {
+    id: types.identifierNumber,
+    name: types.string,
+  });
+  const fooInstance = Foo.create({ id: 1, name: "Lucky" });
+
+  const converter = converters.modelReferenceArray(Foo);
+  const r = converter.convert([{ id: 1, name: "Lucky" }], baseOptions);
+  expect(r).toEqual({ value: [{ id: 1, name: "Lucky" }] });
+  const r2 = converter.convert([fooInstance], baseOptions);
+  expect(r2).toEqual({ value: [fooInstance] });
+});
+
 test("maybe model converter", () => {
   const M = types.model("M", {
     foo: types.string,


### PR DESCRIPTION
This PR adds support for using the `types.array(types.reference(Model))` type within mobx-state-tree.

Adds the `modelReferenceArray` converter and with it an added default controlled instance to go with it that can handle array types.
