### PR TITLE
NEXTPY-305 -- Fixes for zeroIsEmpty implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 1.34.1
+
+-   Fixed a bug where `zeroIsEmpty` did not work with maybe, maybeNull or dynamic converters.
+-   `emptyImpossible` and `emptyValue` now optionally take a function with state
+    converter options. This means they can also be made dynamic.
+
 # 1.34
 
 -   Added `zeroIsEmpty` parameter for the `stringDecimal` converter. When this is enabled,

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -22,7 +22,7 @@ export interface ConverterOptions<R, V> {
   defaultControlled?: Controlled<R, V>;
   neverRequired?: boolean;
   preprocessRaw?(raw: R, options?: StateConverterOptionsWithContext): R;
-  isEmpty?(raw: R): boolean;
+  isEmpty?(raw: R, options?: StateConverterOptionsWithContext): boolean;
 }
 
 export interface IConverter<R, V> {
@@ -37,7 +37,7 @@ export interface IConverter<R, V> {
   defaultControlled: Controlled<R, V>;
   neverRequired: boolean;
   preprocessRaw(raw: R, options: StateConverterOptionsWithContext): R;
-  isEmpty(raw: R): boolean;
+  isEmpty(raw: R, options: StateConverterOptionsWithContext): boolean;
 }
 
 export class ConversionValue<V> {
@@ -77,11 +77,11 @@ export class Converter<R, V> implements IConverter<R, V> {
     this.neverRequired = !!definition.neverRequired;
   }
 
-  isEmpty(raw: R) {
+  isEmpty(raw: R, options: StateConverterOptionsWithContext) {
     if (this.definition.isEmpty == null) {
       return raw === this.emptyRaw;
     }
-    return this.definition.isEmpty(raw);
+    return this.definition.isEmpty(raw, options);
   }
 
   preprocessRaw(raw: R, options?: StateConverterOptionsWithContext): R {

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -179,8 +179,9 @@ function decimalRender(
 }
 
 function stringDecimal(options: DecimalOptions) {
+  type Options = DecimalOptions & StateConverterOptionsWithContext;
   const emptyRaw = "";
-  function stringDecimalIsEmpty(raw: string, options: DecimalOptions): boolean {
+  function stringDecimalIsEmpty(raw: string, options: Options): boolean {
     if (raw === emptyRaw) {
       return true;
     }
@@ -189,9 +190,12 @@ function stringDecimal(options: DecimalOptions) {
 
   return new StringConverter<string>({
     emptyRaw,
-    isEmpty: (raw: string) => stringDecimalIsEmpty(raw, options),
-    emptyImpossible: !options.zeroIsEmpty,
-    emptyValue: options.zeroIsEmpty ? "0" : undefined,
+    isEmpty: (
+      raw: string,
+      converterOptions: StateConverterOptionsWithContext
+    ) => stringDecimalIsEmpty(raw, { ...options, ...converterOptions }),
+    emptyImpossible: false,
+    emptyValue: "",
     defaultControlled: controlled.value,
     neverRequired: false,
     preprocessRaw(raw: string): string {
@@ -323,6 +327,12 @@ function stringMaybe<R, V>(converter: IConverter<R, V>, emptyValue: V) {
     emptyRaw: "",
     emptyValue: emptyValue,
     defaultControlled: controlled.value,
+    isEmpty(raw: R, options: StateConverterOptionsWithContext) {
+      if (raw == null) {
+        return true;
+      }
+      return converter.isEmpty(raw as R, options);
+    },
     preprocessRaw(raw: R, options: StateConverterOptionsWithContext) {
       if (raw == null) {
         return raw;

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -229,6 +229,7 @@ function stringArray() {
   return new Converter<string[], IObservableArray<string>>({
     emptyRaw: [],
     emptyValue: observable.array([]),
+    isEmpty: (raw: string[]) => raw.length === 0,
     convert(raw) {
       return observable.array(raw);
     },

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -179,9 +179,8 @@ function decimalRender(
 }
 
 function stringDecimal(options: DecimalOptions) {
-  type Options = DecimalOptions & StateConverterOptionsWithContext;
   const emptyRaw = "";
-  function stringDecimalIsEmpty(raw: string, options: Options): boolean {
+  function stringDecimalIsEmpty(raw: string, options: DecimalOptions): boolean {
     if (raw === emptyRaw) {
       return true;
     }
@@ -190,12 +189,10 @@ function stringDecimal(options: DecimalOptions) {
 
   return new StringConverter<string>({
     emptyRaw,
-    isEmpty: (
-      raw: string,
-      converterOptions: StateConverterOptionsWithContext
-    ) => stringDecimalIsEmpty(raw, { ...options, ...converterOptions }),
-    emptyImpossible: false,
-    emptyValue: "",
+    isEmpty: (raw: string) => stringDecimalIsEmpty(raw, options),
+    emptyImpossible: (stateConverterOptions) => !options.zeroIsEmpty,
+    emptyValue: (stateConverterOptions) =>
+      options.zeroIsEmpty ? "0" : undefined,
     defaultControlled: controlled.value,
     neverRequired: false,
     preprocessRaw(raw: string): string {

--- a/src/dynamic-converter.ts
+++ b/src/dynamic-converter.ts
@@ -2,6 +2,8 @@ import {
   IConverter,
   StateConverterOptionsWithContext,
   PartialConverterFactory,
+  converterEmptyImpossible,
+  converterEmptyValue,
 } from "./converter";
 import { FieldAccessor } from "./field-accessor";
 
@@ -19,8 +21,6 @@ function delegatingConverter<R, V>(
 ): IConverter<R, V> {
   return {
     emptyRaw: defaultConverter.emptyRaw,
-    emptyValue: defaultConverter.emptyValue,
-    emptyImpossible: defaultConverter.emptyImpossible,
     defaultControlled: defaultConverter.defaultControlled,
     neverRequired: defaultConverter.neverRequired,
     convert(raw: R, options: StateConverterOptionsWithContext) {
@@ -44,6 +44,18 @@ function delegatingConverter<R, V>(
     isEmpty(raw: R, options: StateConverterOptionsWithContext) {
       return getContextConverter(options.context, options.accessor).isEmpty(
         raw,
+        options
+      );
+    },
+    emptyImpossible(options: StateConverterOptionsWithContext): boolean {
+      return converterEmptyImpossible(
+        getContextConverter(options.context, options.accessor),
+        options
+      );
+    },
+    emptyValue(options: StateConverterOptionsWithContext): V {
+      return converterEmptyValue(
+        getContextConverter(options.context, options.accessor),
         options
       );
     },

--- a/src/dynamic-converter.ts
+++ b/src/dynamic-converter.ts
@@ -41,8 +41,11 @@ function delegatingConverter<R, V>(
         options.accessor
       ).preprocessRaw(raw, options);
     },
-    isEmpty(raw: R) {
-      return defaultConverter.isEmpty(raw);
+    isEmpty(raw: R, options: StateConverterOptionsWithContext) {
+      return getContextConverter(options.context, options.accessor).isEmpty(
+        raw,
+        options
+      );
     },
   };
 }

--- a/src/field-accessor.ts
+++ b/src/field-accessor.ts
@@ -118,10 +118,9 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
     }
     const raw = this.raw;
     const emptyRaw = this.field.converter.emptyRaw;
-    if (Array.isArray(raw) && Array.isArray(emptyRaw)) {
-      return raw.length === emptyRaw.length;
-    }
-    return this.field.converter.isEmpty(raw);
+    const stateConverterOptions =
+      this.state.stateConverterOptionsWithContext(this);
+    return this.field.converter.isEmpty(raw, stateConverterOptions);
   }
 
   @computed
@@ -344,7 +343,9 @@ export class FieldAccessor<R, V> extends AccessorBase implements IAccessor {
 
     raw = this.field.converter.preprocessRaw(raw, stateConverterOptions);
 
-    if (this.field.isRequired(raw, this.required, options)) {
+    if (
+      this.field.isRequired(raw, this.required, options, stateConverterOptions)
+    ) {
       if (!this.field.converter.emptyImpossible) {
         this.setValue(this.field.converter.emptyValue);
       }

--- a/src/form.ts
+++ b/src/form.ts
@@ -274,13 +274,7 @@ export class Field<R, V> {
     required: boolean,
     options: ProcessOptions | undefined
   ): boolean {
-    const emptyRaw = this.converter.emptyRaw;
-    const bothArray = Array.isArray(raw) && Array.isArray(emptyRaw);
-    if (bothArray && (raw as any).length !== (emptyRaw as any).length) {
-      return false;
-    }
-
-    if (!bothArray && raw !== emptyRaw) {
+    if (!this.converter.isEmpty(raw)) {
       return false;
     }
     if (!this.converter.neverRequired && this.converter.emptyImpossible) {

--- a/src/form.ts
+++ b/src/form.ts
@@ -12,6 +12,7 @@ import {
   ConverterOrFactory,
   IConverter,
   StateConverterOptionsWithContext,
+  converterEmptyImpossible,
   makeConverter,
 } from "./converter";
 import { FormState, FormStateOptions } from "./state";
@@ -279,7 +280,10 @@ export class Field<R, V> {
     if (!this.converter.isEmpty(raw, stateConverterOptions)) {
       return false;
     }
-    if (!this.converter.neverRequired && this.converter.emptyImpossible) {
+    if (
+      !this.converter.neverRequired &&
+      converterEmptyImpossible(this.converter, stateConverterOptions)
+    ) {
       return true;
     }
     const ignoreRequired: boolean =

--- a/src/form.ts
+++ b/src/form.ts
@@ -19,6 +19,7 @@ import { Controlled } from "./controlled";
 import { identity } from "./utils";
 import { Query, Source } from "./source";
 import { FieldAccessor } from "./field-accessor";
+import { stat } from "fs";
 
 export type ArrayEntryType<T> = T extends IMSTArray<infer A>
   ? A extends IAnyModelType
@@ -272,9 +273,10 @@ export class Field<R, V> {
   isRequired(
     raw: R,
     required: boolean,
-    options: ProcessOptions | undefined
+    options: ProcessOptions | undefined,
+    stateConverterOptions: StateConverterOptionsWithContext
   ): boolean {
-    if (!this.converter.isEmpty(raw)) {
+    if (!this.converter.isEmpty(raw, stateConverterOptions)) {
       return false;
     }
     if (!this.converter.neverRequired && this.converter.emptyImpossible) {

--- a/src/form.ts
+++ b/src/form.ts
@@ -4,8 +4,6 @@ import {
   ModelInstanceTypeProps,
   Instance,
   getNodeId,
-  IModelType,
-  types,
 } from "mobx-state-tree";
 import {
   ConversionError,
@@ -20,7 +18,6 @@ import { Controlled } from "./controlled";
 import { identity } from "./utils";
 import { Query, Source } from "./source";
 import { FieldAccessor } from "./field-accessor";
-import { stat } from "fs";
 
 export type ArrayEntryType<T> = T extends IMSTArray<infer A>
   ? A extends IAnyModelType

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -768,3 +768,84 @@ test("zero decimal empty and required", () => {
   field.setRaw("0.0012");
   expect(field.isEmptyAndRequired).toBeFalsy();
 });
+
+test("zero decimal maybeNull empty and required", () => {
+  const M = types.model("M", {
+    foo: types.maybeNull(types.string),
+  });
+
+  const form = new Form(M, {
+    foo: new Field(
+      converters.maybeNull(
+        converters.stringDecimal({ decimalPlaces: 2, zeroIsEmpty: true })
+      ),
+      { required: true }
+    ),
+  });
+
+  const o = M.create({ foo: "0" });
+
+  const state = form.state(o);
+  const field = state.field("foo");
+
+  // We expect the field to be empty and required, since zeroIsEmpty is true and the raw is "0".
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We expect the field to still be empty and required, since zeroIsEmpty is true and the raw is "0.00".
+  // This is equivalent to 0.
+  field.setRaw("0.00");
+
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We expect the field to still be empty and required, since zeroIsEmpty is true and the raw is "".
+  // This is equivalent to the empty raw.
+  field.setRaw("");
+
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We no longer expect the field to be empty and required, since zeroIsEmpty is true but the raw is "0.0012".
+  // This is equivalent to 0.0012, which isn't technically 0.
+  field.setRaw("0.0012");
+  expect(field.isEmptyAndRequired).toBeFalsy();
+});
+
+test("zero decimal dynamic empty and required", () => {
+  const M = types.model("M", {
+    foo: types.string,
+  });
+
+  const getOptions = (context: any, accessor: FieldAccessor<any, any>) => {
+    return { decimalPlaces: 2, zeroIsEmpty: true };
+  };
+
+  const form = new Form(M, {
+    foo: new Field(converters.dynamic(converters.stringDecimal, getOptions), {
+      required: true,
+    }),
+  });
+
+  const o = M.create({ foo: "0" });
+
+  const state = form.state(o);
+  const field = state.field("foo");
+
+  // We expect the field to be empty and required, since zeroIsEmpty is true and the raw is "0".
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We expect the field to still be empty and required, since zeroIsEmpty is true and the raw is "0.00".
+  // This is equivalent to 0.
+  field.setRaw("0.00");
+
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We expect the field to still be empty and required, since zeroIsEmpty is true and the raw is "".
+  // This is equivalent to the empty raw.
+  field.setRaw("");
+
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We no longer expect the field to be empty and required, since zeroIsEmpty is true but the raw is "0.0012".
+  // This is equivalent to 0.0012, which isn't technically 0.
+  field.setRaw("0.0012");
+  expect(field.isEmptyAndRequired).toBeFalsy();
+});

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -849,3 +849,43 @@ test("zero decimal dynamic empty and required", () => {
   field.setRaw("0.0012");
   expect(field.isEmptyAndRequired).toBeFalsy();
 });
+
+test("zero decimal maybe empty and required", () => {
+  const M = types.model("M", {
+    foo: types.maybe(types.string),
+  });
+
+  const form = new Form(M, {
+    foo: new Field(
+      converters.maybe(
+        converters.stringDecimal({ decimalPlaces: 2, zeroIsEmpty: true })
+      ),
+      { required: true }
+    ),
+  });
+
+  const o = M.create({ foo: "0" });
+
+  const state = form.state(o);
+  const field = state.field("foo");
+
+  // We expect the field to be empty and required, since zeroIsEmpty is true and the raw is "0".
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We expect the field to still be empty and required, since zeroIsEmpty is true and the raw is "0.00".
+  // This is equivalent to 0.
+  field.setRaw("0.00");
+
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We expect the field to still be empty and required, since zeroIsEmpty is true and the raw is "".
+  // This is equivalent to the empty raw.
+  field.setRaw("");
+
+  expect(field.isEmptyAndRequired).toBeTruthy();
+
+  // We no longer expect the field to be empty and required, since zeroIsEmpty is true but the raw is "0.0012".
+  // This is equivalent to 0.0012, which isn't technically 0.
+  field.setRaw("0.0012");
+  expect(field.isEmptyAndRequired).toBeFalsy();
+});

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -1011,7 +1011,7 @@ test("required with zeroIsEmpty", () => {
   expect(field.value).toEqual("3");
   field.setRaw("0");
   expect(field.error).toEqual("Required");
-  expect(field.value).toEqual("");
+  expect(field.value).toEqual("0");
 });
 
 test("required with zeroIsEmpty maybeNull field", () => {
@@ -2690,7 +2690,7 @@ test("isEmpty on fields", () => {
   expect(decimalField.isEmpty).toBe(false);
 
   decimalField.setRaw("");
-  expect(decimalField.isEmpty).toBe(true);
+  expect(decimalField.isEmpty).toBe(false);
 
   decimalField.setRaw("123.0");
   expect(decimalField.isEmpty).toBe(false);
@@ -2863,7 +2863,7 @@ test("isEmptyAndRequired on fields", () => {
   expect(requiredDecimalField.isEmptyAndRequired).toBe(false);
 
   requiredDecimalField.setRaw("");
-  expect(requiredDecimalField.isEmptyAndRequired).toBe(true);
+  expect(requiredDecimalField.isEmptyAndRequired).toBe(false);
 
   requiredDecimalField.setRaw("123.0");
   expect(requiredDecimalField.isEmptyAndRequired).toBe(false);

--- a/test/form.test.ts
+++ b/test/form.test.ts
@@ -983,6 +983,30 @@ test("required with maybeNull", () => {
   expect(field.value).toBeNull();
 });
 
+test("required with zeroIsEmpty", () => {
+  const M = types.model("M", {
+    foo: types.string,
+  });
+
+  const form = new Form(M, {
+    foo: new Field(converters.stringDecimal({ zeroIsEmpty: true }), {
+      required: true,
+    }),
+  });
+
+  const o = M.create({ foo: "3" });
+
+  const state = form.state(o);
+
+  const field = state.field("foo");
+
+  expect(field.raw).toEqual("3.00");
+  expect(field.value).toEqual("3");
+  field.setRaw("0");
+  expect(field.error).toEqual("Required");
+  expect(field.value).toEqual("0");
+});
+
 test("setting value on model will update form", () => {
   const M = types
     .model("M", {


### PR DESCRIPTION
Fixed a bug where `zeroIsEmpty` did not work with maybe, maybeNull or dynamic converters.

`emptyImpossible` and `emptyValue` now optionally take a function with state converter options. This means they can also be made dynamic. I made a few helper functions to determine which version to use.

Added better test coverage.