### PR TITLE
NEXTPY-609 -- modelReferenceArray isEmpty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.34.2
+
+-   Fixed a bug with the `modelReferenceArray` converter - it was missing its isEmpty hook,
+    causing the `required` functionality to stop working for these fields.
+
 # 1.34.1
 
 -   Fixed a bug where `zeroIsEmpty` did not work with maybe, maybeNull or dynamic converters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.34.0",
+    "version": "1.34.1",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -396,6 +396,7 @@ function modelReferenceArray<M extends IAnyModelType>(_model: M) {
   return new Converter<Instance<M>[], IMSTArray<IReferenceType<M>>>({
     emptyRaw: [],
     emptyValue: observable.array([]),
+    isEmpty: (raw: IAnyModelType[]) => raw.length === 0,
     defaultControlled: controlled.modelReferenceArray,
     convert(raw) {
       return raw as IMSTArray<IReferenceType<M>>;


### PR DESCRIPTION
Oops! The modelReferenceArray converter needed an isEmpty hook, but it was missing. Since there was no test for this, I had missed this during my initial implementation.
Added a test first, then fixed the behavior.