### PR TITLE
NEXTPY-645, Fixed bug where decimals where falsely marked as empty

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.34.3
+
+- Fixed bug where decimals where falsely marked as empty for localizations that use comma as decimal separator
+
 # 1.34.2
 
 -   Fixed a bug with the `modelReferenceArray` converter - it was missing its isEmpty hook,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.34.2",
+    "version": "1.34.3",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -180,16 +180,32 @@ function decimalRender(
 
 function stringDecimal(options: DecimalOptions) {
   const emptyRaw = "";
-  function stringDecimalIsEmpty(raw: string, options: DecimalOptions): boolean {
+  function stringDecimalIsEmpty(
+    raw: string,
+    options: DecimalOptions,
+    extraOptions: StateConverterOptionsWithContext
+  ): boolean {
     if (raw === emptyRaw) {
       return true;
+    }
+    if (raw) {
+      if (extraOptions.thousandSeparator) {
+        raw.replaceAll(extraOptions.thousandSeparator, "");
+      }
+      if (
+        extraOptions.decimalSeparator &&
+        extraOptions.decimalSeparator !== "."
+      ) {
+        raw = raw.replaceAll(extraOptions.decimalSeparator, ".");
+      }
     }
     return options.zeroIsEmpty ? parseFloat(raw) === 0 : false;
   }
 
   return new StringConverter<string>({
     emptyRaw,
-    isEmpty: (raw: string) => stringDecimalIsEmpty(raw, options),
+    isEmpty: (raw: string, extraOptions: StateConverterOptionsWithContext) =>
+      stringDecimalIsEmpty(raw, options, extraOptions),
     emptyImpossible: (stateConverterOptions) => !options.zeroIsEmpty,
     emptyValue: (stateConverterOptions) =>
       options.zeroIsEmpty ? "0" : undefined,

--- a/test/converters.test.ts
+++ b/test/converters.test.ts
@@ -769,6 +769,35 @@ test("zero decimal empty and required", () => {
   expect(field.isEmptyAndRequired).toBeFalsy();
 });
 
+test("decimals should not be marked as empty", () => {
+  const M = types.model("M", {
+    foo: types.string,
+  });
+
+  const form = new Form(M, {
+    foo: new Field(
+      converters.stringDecimal({ decimalPlaces: 2, zeroIsEmpty: true }),
+      { required: true }
+    ),
+  });
+
+  const o = M.create({ foo: "0" });
+
+  const state = form.state(o, {
+    converterOptions: {
+      decimalSeparator: ",",
+      thousandSeparator: ".",
+    },
+  });
+  const field = state.field("foo");
+
+  field.setRaw("0,02");
+  expect(field.isEmptyAndRequired).toBeFalsy();
+
+  field.setRaw("0.02");
+  expect(field.isEmptyAndRequired).toBeFalsy();
+});
+
 test("zero decimal maybeNull empty and required", () => {
   const M = types.model("M", {
     foo: types.maybeNull(types.string),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "moduleResolution": "node",
         "target": "es5",
         "module": "es2015",
-        "lib": ["es2015", "es2016", "es2017", "es2020", "dom"],
+        "lib": ["es2015", "es2016", "es2017", "es2020", "es2021", "dom"],
         "sourceMap": true,
         "strict": true,
         "strictPropertyInitialization": true,


### PR DESCRIPTION
**Changes**
Decimals would be marked as empty when the value was below 0, zeroIsEmpty was true and the decimal separator was a comma. This has now been fixed.