### PR TITLE
Non recursive loop when using flatAccessors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.34.6
+
+- The `flatAccessor` getter has been updated to use an iterative approach for retrieving all sub-accessors, 
+  to prevent the risk of exceeding the maximum call stack limit.
+
 # 1.34.5
 
 - hasChange method in dynamic converter should not execute but pass down its check to the child converter

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mstform",
-    "version": "1.34.5",
+    "version": "1.34.6",
     "description": "mobx-state-tree powered forms",
     "main": "dist/mstform.js",
     "typings": "dist/src/index.d.ts",

--- a/src/accessor-base.ts
+++ b/src/accessor-base.ts
@@ -163,10 +163,14 @@ export abstract class AccessorBase implements IAccessor {
   @computed
   get flatAccessors(): IAccessor[] {
     const result: IAccessor[] = [];
-    this.accessors.forEach((accessor) => {
-      result.push(...accessor.flatAccessors);
-      result.push(accessor);
-    });
+    const processStack: IAccessor[] = this.accessors;
+    while (processStack.length > 0) {
+      const accessor: IAccessor = processStack.pop() as IAccessor; // Use pop for O(1) performance
+      if (accessor !== this) {
+        result.push(accessor);
+        processStack.push(...accessor.accessors); // Use push with spread operator for better efficiency
+      }
+    }
     return result;
   }
 

--- a/test/accessor.test.ts
+++ b/test/accessor.test.ts
@@ -1,5 +1,5 @@
 import { configure } from "mobx";
-import { types } from "mobx-state-tree";
+import { Instance, types } from "mobx-state-tree";
 import {
   Field,
   Form,
@@ -9,6 +9,7 @@ import {
   converters,
   FieldAccessor,
   Group,
+  IAccessor,
 } from "../src";
 
 configure({ enforceActions: "always" });
@@ -142,4 +143,100 @@ test("groups with indexed repeatingform error on top-level", async () => {
 
   expect(indexedRepeatingForm.isValid).toBeFalsy();
   expect(indexedRepeatingForm.isWarningFree).toBeFalsy();
+});
+
+test("flatAccessors should return correct accessors", () => {
+  // Define Line3 model (deepest level)
+  const Line3 = types.model("Line3", {
+    value: types.string, // Line3 value
+  });
+  // Define Line2 model (middle level, contains Line3)
+  const Line2 = types
+    .model("Line2", {
+      value: types.string, // Line2 value
+      lines: types.array(Line3), // Each Line2 contains an array of Line3
+    })
+    .actions((self) => ({
+      addLine(line: Instance<typeof Line3>) {
+        self.lines.push(line);
+      },
+    }));
+
+  // Define Line1 model (top level of lines, contains Line2)
+  const Line1 = types
+    .model("Line1", {
+      value: types.string, // Line1 value
+      lines: types.array(Line2), // Each Line1 contains an array of Line2
+    })
+    .actions((self) => ({
+      addLine(line: Instance<typeof Line2>) {
+        self.lines.push(line);
+      },
+    }));
+
+  // Define the Bar model (contains Line1)
+  const Bar = types
+    .model("Bar", {
+      lines: types.array(Line1), // Each Bar contains an array of Line1
+    })
+    .actions((self) => ({
+      addLines() {
+        // Adding 1000 Line1 elements, each containing 100 Line2 elements, each containing 10 Line3 elements
+        for (let i = 0; i < 100; i++) {
+          const line1 = Line1.create({
+            value: `Line1 #${i}`,
+            lines: [],
+          });
+
+          for (let j = 0; j < 10; j++) {
+            const line2 = Line2.create({
+              value: `Line2 #${j}`,
+              lines: [],
+            });
+
+            for (let k = 0; k < 1; k++) {
+              const line3 = Line3.create({
+                value: `Line3 #${k}`,
+              });
+              line2.addLine(line3); // Add 10 Line3 instances to Line2
+            }
+
+            line1.addLine(line2); // Add 100 Line2 instances to Line1
+          }
+
+          self.lines.push(line1); // Add 1000 Line1 instances to Bar
+        }
+      },
+    }));
+
+  const barForm = new Form(Bar, {
+    lines: new RepeatingForm({
+      value: new Field(converters.string),
+      lines: new RepeatingForm({
+        value: new Field(converters.string),
+        lines: new RepeatingForm({
+          value: new Field(converters.string),
+        }),
+      }),
+    }),
+  });
+  const barObj = Bar.create();
+  const state = barForm.state(barObj);
+  barObj.addLines();
+  const flatAccessorOldFunc = () => {
+    const result: IAccessor[] = [];
+    state.accessors.forEach((accessor) => {
+      result.push(...accessor.flatAccessors);
+      result.push(accessor);
+    });
+    return result;
+  };
+
+  const accessorsOld = flatAccessorOldFunc();
+  const accessorsNew = state.flatAccessors;
+
+  expect(accessorsOld.length === accessorsNew.length).toBeTruthy();
+  for (const accessorOld of accessorsOld) {
+    expect(accessorsNew.includes(accessorOld)).toBeTruthy();
+  }
 });

--- a/test/accessor.test.ts
+++ b/test/accessor.test.ts
@@ -181,7 +181,7 @@ test("flatAccessors should return correct accessors", () => {
     })
     .actions((self) => ({
       addLines() {
-        // Adding 1000 Line1 elements, each containing 100 Line2 elements, each containing 10 Line3 elements
+        // Adding 100 Line1 elements, each containing 100 Line2 elements, each containing 10 Line3 elements
         for (let i = 0; i < 100; i++) {
           const line1 = Line1.create({
             value: `Line1 #${i}`,
@@ -198,13 +198,13 @@ test("flatAccessors should return correct accessors", () => {
               const line3 = Line3.create({
                 value: `Line3 #${k}`,
               });
-              line2.addLine(line3); // Add 10 Line3 instances to Line2
+              line2.addLine(line3); // Add 1 Line3 instances to Line2
             }
 
-            line1.addLine(line2); // Add 100 Line2 instances to Line1
+            line1.addLine(line2); // Add 10 Line2 instances to Line1
           }
 
-          self.lines.push(line1); // Add 1000 Line1 instances to Bar
+          self.lines.push(line1); // Add 100 Line1 instances to Bar
         }
       },
     }));
@@ -222,7 +222,10 @@ test("flatAccessors should return correct accessors", () => {
   });
   const barObj = Bar.create();
   const state = barForm.state(barObj);
+  // we add lines 100 x 10 x 1
   barObj.addLines();
+
+  // this was how the old flatAccessor method worked
   const flatAccessorOldFunc = () => {
     const result: IAccessor[] = [];
     state.accessors.forEach((accessor) => {
@@ -235,6 +238,7 @@ test("flatAccessors should return correct accessors", () => {
   const accessorsOld = flatAccessorOldFunc();
   const accessorsNew = state.flatAccessors;
 
+  // now we make sure that the length is the same and it contains the same values
   expect(accessorsOld.length === accessorsNew.length).toBeTruthy();
   for (const accessorOld of accessorsOld) {
     expect(accessorsNew.includes(accessorOld)).toBeTruthy();


### PR DESCRIPTION
The recursive loop when executing flatAccessors can in some cases lead to maximum call stack error, to prevent this it has been transformed to a non recursive loop. Downside is that we use pop instead of shift causing the flatAccessor list not to be ordered chronologically.
