### PR TITLE
NEXTPY-3120 - fix isvalid check not using the formstate wide errorValue

### DIFF
--- a/src/form-accessor-base.ts
+++ b/src/form-accessor-base.ts
@@ -83,7 +83,10 @@ export abstract class FormAccessorBase<
 
   @computed
   get isValid(): boolean {
-    return this.accessors.every((accessor) => accessor.isValid);
+    return (
+      this.errorValue == null &&
+      this.accessors.every((accessor) => accessor.isValid)
+    );
   }
 
   @computed

--- a/src/repeating-form-indexed-accessor.ts
+++ b/src/repeating-form-indexed-accessor.ts
@@ -51,14 +51,6 @@ export class RepeatingFormIndexedAccessor<
   }
 
   @override
-  get isValid(): boolean {
-    return (
-      this.errorValue == null &&
-      this.accessors.every((accessor) => accessor.isValid)
-    );
-  }
-
-  @override
   get value(): Instance<M> {
     return this.state.getValue(this.path);
   }

--- a/src/sub-form-accessor.ts
+++ b/src/sub-form-accessor.ts
@@ -36,12 +36,4 @@ export class SubFormAccessor<
   get value(): Instance<M> {
     return this.state.getValue(this.path);
   }
-
-  @override
-  get isValid(): boolean {
-    return (
-      this.errorValue == null &&
-      this.accessors.every((accessor) => accessor.isValid)
-    );
-  }
 }


### PR DESCRIPTION
Seems that there was a "bug" in our `isValid` functionality..

If the head accessorbase has errorValue, yet none of the child lists had an error, it would return as "no error". 
- This had already been fixed for the subform accessor, as well as the repeating form accessor
- As this is now used for all 3 children of accessorbase, might as well remove the specializations in the subform accessor and repeat form accessor.


This can be seen in ispnext develop:

![image](https://github.com/user-attachments/assets/ea2300ea-be1d-4eec-8581-f055b7b301f6)
